### PR TITLE
Add architecture info in installation pages

### DIFF
--- a/docs/docs/0.1.2/installation/centos.md
+++ b/docs/docs/0.1.2/installation/centos.md
@@ -1,4 +1,4 @@
-# CentOS
+# CentOS (x86\_64)
 
 ::: tip
 **Don't forget!** The [Official Documentation](/docs/0.1.2/) of Kuma is a great place to learn about both basic and more advanced topics.

--- a/docs/docs/0.1.2/installation/debian.md
+++ b/docs/docs/0.1.2/installation/debian.md
@@ -1,4 +1,4 @@
-# Debian
+# Debian (amd64)
 
 ::: tip
 **Don't forget!** The [Official Documentation](/docs/0.1.2/) of Kuma is a great place to learn about both basic and more advanced topics.

--- a/docs/docs/0.1.2/installation/redhat.md
+++ b/docs/docs/0.1.2/installation/redhat.md
@@ -1,4 +1,4 @@
-# RedHat
+# RedHat (x86\_64)
 
 ::: tip
 **Don't forget!** The [Official Documentation](/docs/0.1.2/) of Kuma is a great place to learn about both basic and more advanced topics.

--- a/docs/docs/0.1.2/installation/ubuntu.md
+++ b/docs/docs/0.1.2/installation/ubuntu.md
@@ -1,4 +1,4 @@
-# Ubuntu
+# Ubuntu (amd64)
 
 ::: tip
 **Don't forget!** The [Official Documentation](/docs/0.1.2/) of Kuma is a great place to learn about both basic and more advanced topics.


### PR DESCRIPTION
Currently, all the downloadable tarballs referred to in the installation
documentation are amd64/x86_64 ones. This patch adds info about that in
the page titles in order for us who run e.g. Ubuntu/aarch64 and similar
Linux + non-PC HW systems to be mislead.

Change-Id: I9b59b1c8b20f6f66119e325650973ff02850f623
Signed-off-by: Joakim Roubert <joakimr@axis.com>