### PR TITLE
feat(docs) new latest redirect splat

### DIFF
--- a/setup-redirects/index.js
+++ b/setup-redirects/index.js
@@ -27,10 +27,17 @@ to = "/install/${latest}/"
 status = 301
 force = false
 
-# Latest redirect
+# Docs: Latest redirect
 [[redirects]]
 from = "/docs/latest/*"
 to = "/docs/${latest}/:splat"
+status = 301
+force = false
+
+# Install: Latest redirect
+[[redirects]]
+from = "/install/latest/*"
+to = "/install/${latest}/:splat"
 status = 301
 force = false`;
 

--- a/setup-redirects/index.js
+++ b/setup-redirects/index.js
@@ -25,6 +25,13 @@ force = false
 from = "/install/"
 to = "/install/${latest}/"
 status = 301
+force = false
+
+# Latest redirect
+[[redirects]]
+from = "/docs/latest/*"
+to = "/docs/${latest}/:splat"
+status = 301
 force = false`;
 
   // write our redirects to the TOML file


### PR DESCRIPTION
Using `.../docs/latest` will now always redirect to the latest version.

### Test:
* https://feat-latest-version-redirect--kuma.netlify.com/docs/latest/
* https://feat-latest-version-redirect--kuma.netlify.com/docs/0.1.2/documentation/#universal-mode

**Note:** This is a redirect that is setup for Netlify, so it won't work locally.