### PR TITLE
docs(*) kuma-dp start arguments

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -154,10 +154,10 @@ networking:
     tags:
       service: echo" | kumactl apply -f -
 
-$ KUMA_CONTROL_PLANE_BOOTSTRAP_SERVER_URL=http://127.0.0.1:5682 \
-  KUMA_DATAPLANE_MESH=default \
-  KUMA_DATAPLANE_NAME=dp-echo-1 \
-  kuma-dp run
+$ kuma-dp run \
+    --name=dp-echo-1 \
+    --mesh=default \
+    --cp-address=http://127.0.0.1:5682
 ```
 :::
 

--- a/docs/docs/0.1.2/documentation/README.md
+++ b/docs/docs/0.1.2/documentation/README.md
@@ -210,10 +210,10 @@ networking:
     tags:
       service: redis" | kumactl apply -f -
 
-KUMA_CONTROL_PLANE_BOOTSTRAP_SERVER_URL=http://control-plane:5682 \
-KUMA_DATAPLANE_MESH=default \
-KUMA_DATAPLANE_NAME=redis-1 \
-kuma-dp run
+kuma-dp run \
+    --name=redis-1 \
+    --mesh=default \
+    --cp-address=http://127.0.0.1:5682
 ```
 
 In the example above, any external client who wants to consume Redis will have to make a request to the DP on port `9000`, which internally will be redirected to the Redis service listening on port `6379`.
@@ -233,10 +233,10 @@ networking:
   - interface: :10000
     service: redis" | kumactl apply -f -
 
-KUMA_CONTROL_PLANE_BOOTSTRAP_SERVER_URL=http://control-plane:5682 \
-KUMA_DATAPLANE_MESH=default \
-KUMA_DATAPLANE_NAME=backend-1 \
-kuma-dp run
+kuma-dp run \
+    --name=backend-1 \
+    --mesh=default \
+    --cp-address=http://127.0.0.1:5682
 ```
 
 In order for the `backend` service to successfully consume `redis`, we specify an `outbound` networking section in the `Dataplane` configuration instructing the DP to listen on a new port `10000` and to proxy any outgoing request on port `10000` to the `redis` service. For this to work, we must update our application to consume `redis` on `127.0.0.1:10000`.
@@ -247,7 +247,7 @@ As mentioned before, this is only required in Universal. In Kubernetes no change
 
 ### Envoy
 
-Since `kuma-dp` is built on top of Envoy, you can enable the [Envoy HTTP API](https://www.envoyproxy.io/docs/envoy/latest/operations/admin) by starting `kuma-dp` with an additional `KUMA_DATAPLANE_ADMIN_PORT=9901` environment variable (or by setting the `--admin-port=9901` argument). This can be very useful for debugging purposes.
+Since `kuma-dp` is built on top of Envoy, you can enable the [Envoy HTTP API](https://www.envoyproxy.io/docs/envoy/latest/operations/admin) by starting `kuma-dp` by setting the `--admin-port=9901` argument. This can be very useful for debugging purposes.
 
 ### Tags
 

--- a/docs/docs/0.1.2/installation/centos.md
+++ b/docs/docs/0.1.2/installation/centos.md
@@ -62,10 +62,10 @@ networking:
 And run the actual data-plane process with:
 
 ```sh
-$ KUMA_CONTROL_PLANE_BOOTSTRAP_SERVER_URL=http://127.0.0.1:5682 \
-  KUMA_DATAPLANE_MESH=default \
-  KUMA_DATAPLANE_NAME=dp-echo-1 \
-  kuma-dp run
+$ kuma-dp run \
+    --name=dp-echo-1 \
+    --mesh=default \
+    --cp-address=http://127.0.0.1:5682
 ```
 
 You can now consume the service on port `10000`, which will be internally redirected to the service on port `9000`:

--- a/docs/docs/0.1.2/installation/debian.md
+++ b/docs/docs/0.1.2/installation/debian.md
@@ -62,10 +62,10 @@ networking:
 And run the actual data-plane process with:
 
 ```sh
-$ KUMA_CONTROL_PLANE_BOOTSTRAP_SERVER_URL=http://127.0.0.1:5682 \
-  KUMA_DATAPLANE_MESH=default \
-  KUMA_DATAPLANE_NAME=dp-echo-1 \
-  kuma-dp run
+$ kuma-dp run \
+    --name=dp-echo-1 \
+    --mesh=default \
+    --cp-address=http://127.0.0.1:5682
 ```
 
 You can now consume the service on port `10000`, which will be internally redirected to the service on port `9000`:

--- a/docs/docs/0.1.2/installation/macos.md
+++ b/docs/docs/0.1.2/installation/macos.md
@@ -62,10 +62,10 @@ networking:
 And run the actual data-plane process with:
 
 ```sh
-$ KUMA_CONTROL_PLANE_BOOTSTRAP_SERVER_URL=http://127.0.0.1:5682 \
-  KUMA_DATAPLANE_MESH=default \
-  KUMA_DATAPLANE_NAME=dp-echo-1 \
-  kuma-dp run
+$ kuma-dp run \
+    --name=dp-echo-1 \
+    --mesh=default \
+    --cp-address=http://127.0.0.1:5682
 ```
 
 You can now consume the service on port `10000`, which will be internally redirected to the service on port `9000`:

--- a/docs/docs/0.1.2/installation/redhat.md
+++ b/docs/docs/0.1.2/installation/redhat.md
@@ -62,10 +62,10 @@ networking:
 And run the actual data-plane process with:
 
 ```sh
-$ KUMA_CONTROL_PLANE_BOOTSTRAP_SERVER_URL=http://127.0.0.1:5682 \
-  KUMA_DATAPLANE_MESH=default \
-  KUMA_DATAPLANE_NAME=dp-echo-1 \
-  kuma-dp run
+$ kuma-dp run \
+    --name=dp-echo-1 \
+    --mesh=default \
+    --cp-address=http://127.0.0.1:5682
 ```
 
 You can now consume the service on port `10000`, which will be internally redirected to the service on port `9000`:

--- a/docs/docs/0.1.2/installation/ubuntu.md
+++ b/docs/docs/0.1.2/installation/ubuntu.md
@@ -62,10 +62,10 @@ networking:
 And run the actual data-plane process with:
 
 ```sh
-$ KUMA_CONTROL_PLANE_BOOTSTRAP_SERVER_URL=http://127.0.0.1:5682 \
-  KUMA_DATAPLANE_MESH=default \
-  KUMA_DATAPLANE_NAME=dp-echo-1 \
-  kuma-dp run
+$ kuma-dp run \
+    --name=dp-echo-1 \
+    --mesh=default \
+    --cp-address=http://127.0.0.1:5682
 ```
 
 You can now consume the service on port `10000`, which will be internally redirected to the service on port `9000`:


### PR DESCRIPTION
It's more natural and elegant to run kuma-dp with arg vars.