### PR TITLE
docs: update configuration examples for 0.3.0 release

### DIFF
--- a/docs/docs/0.1.0/policies/README.md
+++ b/docs/docs/0.1.0/policies/README.md
@@ -147,7 +147,7 @@ spec:
 ```
 
 ::: tip
-**Match-All**: You can match any value of a tag by using `*`, like `version: *`.
+**Match-All**: You can match any value of a tag by using `*`, like `version: '*'`.
 :::
 
 ## Traffic Route
@@ -174,12 +174,12 @@ rules:
     conf:
       - weight: 90
         destination:
-          - service: backend
-            version: "1.0"
+          service: backend
+          version: '1.0'
       - weight: 10
         destination:
-          - service: backend
-            version: "2.0"
+          service: backend
+          version: '2.0'
 ```
 
 On Kubernetes:
@@ -202,12 +202,12 @@ spec:
     conf:
       - weight: 90
         destination:
-          - service: backend
-            version: "1.0"
+          service: backend
+          version: '1.0'
       - weight: 10
         destination:
-          - service: backend
-            version: "2.0"
+          service: backend
+          version: '2.0'
 ```
 
 ## Traffic Tracing
@@ -292,12 +292,11 @@ name: template-1
 selectors:
   - match:
       service: backend
-conf:
-  imports:
-    - default-proxy
-  resources:
-    - ..
-    - ..
+imports:
+  - default-proxy
+resources:
+  - ..
+  - ..
 ```
 
 On Kubernetes:
@@ -309,10 +308,10 @@ mesh: default
 metadata:
   namespace: default
   name: template-1
-selectors:
-  - match:
-      service: backend
-conf:
+spec:
+  selectors:
+    - match:
+        service: backend
   imports:
     - default-proxy
   resources:
@@ -359,11 +358,11 @@ imports:
                 virtual_hosts:
                 - routes:
                   - match:
-                      prefix: "/stats/prometheus"
+                      prefix: /stats/prometheus
                     route:
                       cluster: localhost:9901
                   domains:
-                  - "*"
+                  - '*'
                   name: envoy_admin
               codec_type: AUTO
               http_filters:

--- a/docs/docs/0.1.1/policies/README.md
+++ b/docs/docs/0.1.1/policies/README.md
@@ -147,7 +147,7 @@ spec:
 ```
 
 ::: tip
-**Match-All**: You can match any value of a tag by using `*`, like `version: *`.
+**Match-All**: You can match any value of a tag by using `*`, like `version: '*'`.
 :::
 
 ## Traffic Route
@@ -174,12 +174,12 @@ rules:
     conf:
       - weight: 90
         destination:
-          - service: backend
-            version: "1.0"
+          service: backend
+          version: '1.0'
       - weight: 10
         destination:
-          - service: backend
-            version: "2.0"
+          service: backend
+          version: '2.0'
 ```
 
 On Kubernetes:
@@ -202,12 +202,12 @@ spec:
     conf:
       - weight: 90
         destination:
-          - service: backend
-            version: "1.0"
+          service: backend
+          version: '1.0'
       - weight: 10
         destination:
-          - service: backend
-            version: "2.0"
+          service: backend
+          version: '2.0'
 ```
 
 ## Traffic Tracing
@@ -292,12 +292,11 @@ name: template-1
 selectors:
   - match:
       service: backend
-conf:
-  imports:
-    - default-proxy
-  resources:
-    - ..
-    - ..
+imports:
+  - default-proxy
+resources:
+  - ..
+  - ..
 ```
 
 On Kubernetes:
@@ -309,10 +308,10 @@ mesh: default
 metadata:
   namespace: default
   name: template-1
-selectors:
-  - match:
-      service: backend
-conf:
+spec:
+  selectors:
+    - match:
+        service: backend
   imports:
     - default-proxy
   resources:
@@ -323,7 +322,7 @@ conf:
 Below you can find an example of what a `ProxyTemplate` configuration could look like:
 
 ```yaml
-imports:
+  imports:
     - default-proxy
   resources:
     - name: localhost:9901
@@ -359,11 +358,11 @@ imports:
                 virtual_hosts:
                 - routes:
                   - match:
-                      prefix: "/stats/prometheus"
+                      prefix: /stats/prometheus
                     route:
                       cluster: localhost:9901
                   domains:
-                  - "*"
+                  - '*'
                   name: envoy_admin
               codec_type: AUTO
               http_filters:

--- a/docs/docs/0.1.2/policies/README.md
+++ b/docs/docs/0.1.2/policies/README.md
@@ -147,7 +147,7 @@ spec:
 ```
 
 ::: tip
-**Match-All**: You can match any value of a tag by using `*`, like `version: *`.
+**Match-All**: You can match any value of a tag by using `*`, like `version: '*'`.
 :::
 
 ## Traffic Route
@@ -174,12 +174,12 @@ rules:
     conf:
       - weight: 90
         destination:
-          - service: redis
-            version: "1.0"
+          service: redis
+          version: '1.0'
       - weight: 10
         destination:
-          - service: redis
-            version: "2.0"
+          service: redis
+          version: '2.0'
 ```
 
 On Kubernetes:
@@ -202,12 +202,12 @@ spec:
     conf:
       - weight: 90
         destination:
-          - service: redis
-            version: "1.0"
+          service: redis
+          version: '1.0'
       - weight: 10
         destination:
-          - service: redis
-            version: "2.0"
+          service: redis
+          version: '2.0'
 ```
 
 ## Traffic Tracing
@@ -292,12 +292,11 @@ name: template-1
 selectors:
   - match:
       service: backend
-conf:
-  imports:
-    - default-proxy
-  resources:
-    - ..
-    - ..
+imports:
+  - default-proxy
+resources:
+  - ..
+  - ..
 ```
 
 On Kubernetes:
@@ -309,10 +308,10 @@ mesh: default
 metadata:
   namespace: default
   name: template-1
-selectors:
-  - match:
-      service: backend
-conf:
+spec:
+  selectors:
+    - match:
+        service: backend
   imports:
     - default-proxy
   resources:
@@ -323,7 +322,7 @@ conf:
 Below you can find an example of what a `ProxyTemplate` configuration could look like:
 
 ```yaml
-imports:
+  imports:
     - default-proxy
   resources:
     - name: localhost:9901
@@ -359,11 +358,11 @@ imports:
                 virtual_hosts:
                 - routes:
                   - match:
-                      prefix: "/stats/prometheus"
+                      prefix: /stats/prometheus
                     route:
                       cluster: localhost:9901
                   domains:
-                  - "*"
+                  - '*'
                   name: envoy_admin
               codec_type: AUTO
               http_filters:

--- a/docs/docs/0.2.0/policies/README.md
+++ b/docs/docs/0.2.0/policies/README.md
@@ -147,7 +147,7 @@ spec:
 ```
 
 ::: tip
-**Match-All**: You can match any value of a tag by using `*`, like `version: *`.
+**Match-All**: You can match any value of a tag by using `*`, like `version: '*'`.
 :::
 
 ## Traffic Route
@@ -174,12 +174,12 @@ rules:
     conf:
       - weight: 90
         destination:
-          - service: redis
-            version: "1.0"
+          service: redis
+          version: '1.0'
       - weight: 10
         destination:
-          - service: redis
-            version: "2.0"
+          service: redis
+          version: '2.0'
 ```
 
 On Kubernetes:
@@ -202,12 +202,12 @@ spec:
     conf:
       - weight: 90
         destination:
-          - service: redis
-            version: "1.0"
+          service: redis
+          version: '1.0'
       - weight: 10
         destination:
-          - service: redis
-            version: "2.0"
+          service: redis
+          version: '2.0'
 ```
 
 ## Traffic Tracing
@@ -292,12 +292,11 @@ name: template-1
 selectors:
   - match:
       service: backend
-conf:
-  imports:
-    - default-proxy
-  resources:
-    - ..
-    - ..
+imports:
+  - default-proxy
+resources:
+  - ..
+  - ..
 ```
 
 On Kubernetes:
@@ -309,10 +308,10 @@ mesh: default
 metadata:
   namespace: default
   name: template-1
-selectors:
-  - match:
-      service: backend
-conf:
+spec:
+  selectors:
+    - match:
+        service: backend
   imports:
     - default-proxy
   resources:
@@ -323,7 +322,7 @@ conf:
 Below you can find an example of what a `ProxyTemplate` configuration could look like:
 
 ```yaml
-imports:
+  imports:
     - default-proxy
   resources:
     - name: localhost:9901
@@ -359,11 +358,11 @@ imports:
                 virtual_hosts:
                 - routes:
                   - match:
-                      prefix: "/stats/prometheus"
+                      prefix: /stats/prometheus
                     route:
                       cluster: localhost:9901
                   domains:
-                  - "*"
+                  - '*'
                   name: envoy_admin
               codec_type: AUTO
               http_filters:

--- a/docs/docs/0.2.1/policies/README.md
+++ b/docs/docs/0.2.1/policies/README.md
@@ -147,7 +147,7 @@ spec:
 ```
 
 ::: tip
-**Match-All**: You can match any value of a tag by using `*`, like `version: *`.
+**Match-All**: You can match any value of a tag by using `*`, like `version: '*'`.
 :::
 
 ## Traffic Route
@@ -174,12 +174,12 @@ rules:
     conf:
       - weight: 90
         destination:
-          - service: redis
-            version: "1.0"
+          service: redis
+          version: '1.0'
       - weight: 10
         destination:
-          - service: redis
-            version: "2.0"
+          service: redis
+          version: '2.0'
 ```
 
 On Kubernetes:
@@ -202,12 +202,12 @@ spec:
     conf:
       - weight: 90
         destination:
-          - service: redis
-            version: "1.0"
+          service: redis
+          version: '1.0'
       - weight: 10
         destination:
-          - service: redis
-            version: "2.0"
+          service: redis
+          version: '2.0'
 ```
 
 ## Traffic Tracing
@@ -293,10 +293,10 @@ rules:
       backend: logstash
   - sources:
     - match:
-        service: *
+        service: '*'
     destinations:
     - match:
-        service: *
+        service: '*'
 ```
 
 On Kubernetes:
@@ -350,10 +350,10 @@ spec:
         backend: logstash
     - sources:
       - match:
-          service: *
+          service: '*'
       destinations:
       - match:
-          service: *
+          service: '*'
 ```
 
 ::: tip
@@ -383,12 +383,11 @@ name: template-1
 selectors:
   - match:
       service: backend
-conf:
-  imports:
-    - default-proxy
-  resources:
-    - ..
-    - ..
+imports:
+  - default-proxy
+resources:
+  - ..
+  - ..
 ```
 
 On Kubernetes:
@@ -400,10 +399,10 @@ mesh: default
 metadata:
   namespace: default
   name: template-1
-selectors:
-  - match:
-      service: backend
-conf:
+spec:
+  selectors:
+    - match:
+        service: backend
   imports:
     - default-proxy
   resources:
@@ -414,7 +413,7 @@ conf:
 Below you can find an example of what a `ProxyTemplate` configuration could look like:
 
 ```yaml
-imports:
+  imports:
     - default-proxy
   resources:
     - name: localhost:9901
@@ -450,11 +449,11 @@ imports:
                 virtual_hosts:
                 - routes:
                   - match:
-                      prefix: "/stats/prometheus"
+                      prefix: /stats/prometheus
                     route:
                       cluster: localhost:9901
                   domains:
-                  - "*"
+                  - '*'
                   name: envoy_admin
               codec_type: AUTO
               http_filters:

--- a/docs/docs/0.2.2/policies/README.md
+++ b/docs/docs/0.2.2/policies/README.md
@@ -152,7 +152,7 @@ spec:
 ```
 
 ::: tip
-**Match-All**: You can match any value of a tag by using `*`, like `version: *`.
+**Match-All**: You can match any value of a tag by using `*`, like `version: '*'`.
 :::
 
 ## Traffic Route
@@ -179,12 +179,12 @@ rules:
     conf:
       - weight: 90
         destination:
-          - service: redis
-            version: "1.0"
+          service: redis
+          version: '1.0'
       - weight: 10
         destination:
-          - service: redis
-            version: "2.0"
+          service: redis
+          version: '2.0'
 ```
 
 On Kubernetes:
@@ -207,12 +207,12 @@ spec:
     conf:
       - weight: 90
         destination:
-          - service: redis
-            version: "1.0"
+          service: redis
+          version: '1.0'
       - weight: 10
         destination:
-          - service: redis
-            version: "2.0"
+          service: redis
+          version: '2.0'
 ```
 
 ## Traffic Tracing
@@ -298,10 +298,10 @@ rules:
       backend: logstash
   - sources:
     - match:
-        service: *
+        service: '*'
     destinations:
     - match:
-        service: *
+        service: '*'
 ```
 
 On Kubernetes:
@@ -355,10 +355,10 @@ spec:
         backend: logstash
     - sources:
       - match:
-          service: *
+          service: '*'
       destinations:
       - match:
-          service: *
+          service: '*'
 ```
 
 ::: tip
@@ -389,12 +389,11 @@ name: template-1
 selectors:
   - match:
       service: backend
-conf:
-  imports:
-    - default-proxy
-  resources:
-    - ..
-    - ..
+imports:
+  - default-proxy
+resources:
+  - ..
+  - ..
 ```
 
 On Kubernetes:
@@ -406,10 +405,10 @@ mesh: default
 metadata:
   namespace: default
   name: template-1
-selectors:
-  - match:
-      service: backend
-conf:
+spec:
+  selectors:
+    - match:
+        service: backend
   imports:
     - default-proxy
   resources:
@@ -420,7 +419,7 @@ conf:
 Below you can find an example of what a `ProxyTemplate` configuration could look like:
 
 ```yaml
-imports:
+  imports:
     - default-proxy
   resources:
     - name: localhost:9901
@@ -456,11 +455,11 @@ imports:
                 virtual_hosts:
                 - routes:
                   - match:
-                      prefix: "/stats/prometheus"
+                      prefix: /stats/prometheus
                     route:
                       cluster: localhost:9901
                   domains:
-                  - "*"
+                  - '*'
                   name: envoy_admin
               codec_type: AUTO
               http_filters:

--- a/docs/docs/draft/documentation/README.md
+++ b/docs/docs/draft/documentation/README.md
@@ -790,26 +790,28 @@ curl http://localhost:5681/meshes/mesh-1/proxytemplates/pt-1
 ```
 ```json
 {
-  "type": "ProxyTemplate",
-  "name": "pt-1",
-  "mesh": "mesh-1",
-  "selectors": [
-    {
-      "match": {
-          "app": "backend"
-      }
-    }
-  ],
+ "conf": {
   "imports": [
-    "default-proxy"
+   "default-proxy"
   ],
   "resources": [
-    {
-      "name": "raw-name",
-      "version": "raw-version",
-      "resource": "'@type': type.googleapis.com/envoy.api.v2.Cluster\nconnectTimeout: 5s\nloadAssignment:\n  clusterName: localhost:8443\n  endpoints:\n    - lbEndpoints:\n        - endpoint:\n            address:\n              socketAddress:\n                address: 127.0.0.1\n                portValue: 8443\nname: localhost:8443\ntype: STATIC\n"
-    }
+   {
+    "name": "raw-name",
+    "version": "raw-version",
+    "resource": "'@type': type.googleapis.com/envoy.api.v2.Cluster\nconnectTimeout: 5s\nloadAssignment:\n  clusterName: localhost:8443\n  endpoints:\n    - lbEndpoints:\n        - endpoint:\n            address:\n              socketAddress:\n                address: 127.0.0.1\n                portValue: 8443\nname: localhost:8443\ntype: STATIC\n"
+   }
   ]
+ },
+ "mesh": "mesh-1",
+ "name": "pt-1",
+ "selectors": [
+  {
+   "match": {
+    "service": "backend"
+   }
+  }
+ ],
+ "type": "ProxyTemplate"
 }
 ```
 
@@ -830,20 +832,22 @@ curl -XPUT http://localhost:5681/meshes/mesh-1/proxytemplates/pt-1 --data @proxy
   "selectors": [
     {
       "match": {
-          "app": "backend"
+          "service": "backend"
       }
     }
   ],
-  "imports": [
-    "default-proxy"
-  ],
-  "resources": [
-    {
-      "name": "raw-name",
-      "version": "raw-version",
-      "resource": "'@type': type.googleapis.com/envoy.api.v2.Cluster\nconnectTimeout: 5s\nloadAssignment:\n  clusterName: localhost:8443\n  endpoints:\n    - lbEndpoints:\n        - endpoint:\n            address:\n              socketAddress:\n                address: 127.0.0.1\n                portValue: 8443\nname: localhost:8443\ntype: STATIC\n"
-    }
-  ]
+  "conf": {
+    "imports": [
+      "default-proxy"
+    ],
+    "resources": [
+      {
+        "name": "raw-name",
+        "version": "raw-version",
+        "resource": "'@type': type.googleapis.com/envoy.api.v2.Cluster\nconnectTimeout: 5s\nloadAssignment:\n  clusterName: localhost:8443\n  endpoints:\n    - lbEndpoints:\n        - endpoint:\n            address:\n              socketAddress:\n                address: 127.0.0.1\n                portValue: 8443\nname: localhost:8443\ntype: STATIC\n"
+      }
+    ]
+  }
 }
 ```
 
@@ -858,30 +862,32 @@ curl http://localhost:5681/meshes/mesh-1/proxytemplates
 ```
 ```json
 {
-  "items": [
+ "items": [
+  {
+   "conf": {
+    "imports": [
+     "default-proxy"
+    ],
+    "resources": [
+     {
+      "name": "raw-name",
+      "version": "raw-version",
+      "resource": "'@type': type.googleapis.com/envoy.api.v2.Cluster\nconnectTimeout: 5s\nloadAssignment:\n  clusterName: localhost:8443\n  endpoints:\n    - lbEndpoints:\n        - endpoint:\n            address:\n              socketAddress:\n                address: 127.0.0.1\n                portValue: 8443\nname: localhost:8443\ntype: STATIC\n"
+     }
+    ]
+   },
+   "mesh": "mesh-1",
+   "name": "pt-1",
+   "selectors": [
     {
-      "type": "ProxyTemplate",
-      "name": "pt-1",
-      "mesh": "mesh-1",
-      "selectors": [
-        {
-          "match": {
-              "app": "backend"
-          }
-        }
-      ],
-      "imports": [
-        "default-proxy"
-      ],
-      "resources": [
-        {
-          "name": "raw-name",
-          "version": "raw-version",
-          "resource": "'@type': type.googleapis.com/envoy.api.v2.Cluster\nconnectTimeout: 5s\nloadAssignment:\n  clusterName: localhost:8443\n  endpoints:\n    - lbEndpoints:\n        - endpoint:\n            address:\n              socketAddress:\n                address: 127.0.0.1\n                portValue: 8443\nname: localhost:8443\ntype: STATIC\n"
-        }
-      ]
+     "match": {
+      "service": "backend"
+     }
     }
-  ]
+   ],
+   "type": "ProxyTemplate"
+  }
+ ]
 }
 ```
 
@@ -908,63 +914,23 @@ curl http://localhost:5681/meshes/mesh-1/traffic-permissions/tp-1
 ```
 ```json
 {
-  "type": "TrafficPermission",
-  "name": "tp-1",
-  "mesh": "mesh-1",
-  "rules": [
-    {
-      "sources": [
-        {
-          "match": {
-            "service": "web"
-          }
-        }
-      ],
-      "destinations": [
-        {
-          "match": {
-            "service": "backend"
-          }
-        }
-      ]
-    },
-    {
-      "sources": [
-        {
-          "match": {
-            "service": "backend",
-            "version": "1"
-          }
-        }
-      ],
-      "destinations": [
-        {
-          "match": {
-            "service": "redis",
-            "version": "1"
-          }
-        }
-      ]
-    },
-    {
-      "sources": [
-        {
-          "match": {
-            "service": "backend",
-            "version": "2"
-          }
-        }
-      ],
-      "destinations": [
-        {
-          "match": {
-            "service": "redis",
-            "version": "2"
-          }
-        }
-      ]
-    }
-  ]
+ "destinations": [
+  {
+   "match": {
+    "service": "redis"
+   }
+  }
+ ],
+ "mesh": "mesh-1",
+ "name": "tp-1",
+ "sources": [
+  {
+   "match": {
+    "service": "backend"
+   }
+  }
+ ],
+ "type": "TrafficPermission"
 }
 ```
 
@@ -982,58 +948,18 @@ curl -XPUT http://localhost:5681/meshes/mesh-1/traffic-permissions/tp-1 --data @
   "type": "TrafficPermission",
   "name": "tp-1",
   "mesh": "mesh-1",
-  "rules": [
+  "sources": [
     {
-      "sources": [
-        {
-          "match": {
-            "service": "web"
-          }
-        }
-      ],
-      "destinations": [
-        {
-          "match": {
-            "service": "backend"
-          }
-        }
-      ]
-    },
+      "match": {
+        "service": "backend"
+      }
+    }
+  ],
+  "destinations": [
     {
-      "sources": [
-        {
-          "match": {
-            "service": "backend",
-            "version": "1"
-          }
-        }
-      ],
-      "destinations": [
-        {
-          "match": {
-            "service": "redis",
-            "version": "1"
-          }
-        }
-      ]
-    },
-    {
-      "sources": [
-        {
-          "match": {
-            "service": "backend",
-            "version": "2"
-          }
-        }
-      ],
-      "destinations": [
-        {
-          "match": {
-            "service": "redis",
-            "version": "2"
-          }
-        }
-      ]
+      "match": {
+        "service": "redis"
+      }
     }
   ]
 }
@@ -1050,67 +976,27 @@ curl http://localhost:5681/meshes/mesh-1/traffic-permissions
 ```
 ```json
 {
-  "items": [
+ "items": [
+  {
+   "destinations": [
     {
-      "type": "TrafficPermission",
-      "name": "tp-1",
-      "mesh": "mesh-1",
-      "rules": [
-        {
-          "sources": [
-            {
-              "match": {
-                "service": "web"
-              }
-            }
-          ],
-          "destinations": [
-            {
-              "match": {
-                "service": "backend"
-              }
-            }
-          ]
-        },
-        {
-          "sources": [
-            {
-              "match": {
-                "service": "backend",
-                "version": "1"
-              }
-            }
-          ],
-          "destinations": [
-            {
-              "match": {
-                "service": "redis",
-                "version": "1"
-              }
-            }
-          ]
-        },
-        {
-          "sources": [
-            {
-              "match": {
-                "service": "backend",
-                "version": "2"
-              }
-            }
-          ],
-          "destinations": [
-            {
-              "match": {
-                "service": "redis",
-                "version": "2"
-              }
-            }
-          ]
-        }
-      ]
+     "match": {
+      "service": "redis"
+     }
     }
-  ]
+   ],
+   "mesh": "mesh-1",
+   "name": "tp-1",
+   "sources": [
+    {
+     "match": {
+      "service": "backend"
+     }
+    }
+   ],
+   "type": "TrafficPermission"
+  }
+ ]
 }
 ```
 
@@ -1137,48 +1023,27 @@ curl http://localhost:5681/meshes/mesh-1/traffic-logs/tl-1
 ```
 ```json
 {
-  "type": "TrafficLog",
-  "mesh": "mesh-1",
-  "name": "tl-1",
-  "rules": [
-    {
-      "sources": [
-        {
-          "match": {
-            "service": "web",
-            "version": "1.0"
-          }
-        }
-      ],
-      "destinations": [
-        {
-          "match": {
-            "env": "dev",
-            "service": "backend"
-          }
-        }
-      ],
-      "conf": {
-        "backend": "file"
-      }
-    },
-    {
-      "sources": [
-        {
-          "match": {
-            "service": "backend"
-          }
-        }
-      ],
-      "destinations": [
-        {
-          "match": {
-            "service": "redis"
-          }
-        }
-      ]
-    }
-  ]
+ "conf": {
+  "backend": "file"
+ },
+ "destinations": [
+  {
+   "match": {
+    "service": "backend"
+   }
+  }
+ ],
+ "mesh": "mesh-1",
+ "name": "tl-1",
+ "sources": [
+  {
+   "match": {
+    "service": "web",
+    "version": "1.0"
+   }
+  }
+ ],
+ "type": "TrafficLog"
 }
 ```
 
@@ -1196,45 +1061,24 @@ curl -XPUT http://localhost:5681/meshes/mesh-1/traffic-logs/tl-1 --data @traffic
   "type": "TrafficLog",
   "mesh": "mesh-1",
   "name": "tl-1",
-  "rules": [
+  "sources": [
     {
-      "sources": [
-        {
-          "match": {
-            "service": "web",
-            "version": "1.0"
-          }
-        }
-      ],
-      "destinations": [
-        {
-          "match": {
-            "env": "dev",
-            "service": "backend"
-          }
-        }
-      ],
-      "conf": {
-        "backend": "file"
+      "match": {
+        "service": "web",
+        "version": "1.0"
       }
-    },
-    {
-      "sources": [
-        {
-          "match": {
-            "service": "backend"
-          }
-        }
-      ],
-      "destinations": [
-        {
-          "match": {
-            "service": "redis"
-          }
-        }
-      ]
     }
-  ]
+  ],
+  "destinations": [
+    {
+      "match": {
+        "service": "backend"
+      }
+    }
+  ],
+  "conf": {
+    "backend": "file"
+  }
 }
 ```
 
@@ -1249,52 +1093,31 @@ curl http://localhost:5681/meshes/mesh-1/traffic-logs
 ```
 ```json
 {
-  "items": [
+ "items": [
+  {
+   "conf": {
+    "backend": "file"
+   },
+   "destinations": [
     {
-      "type": "TrafficLog",
-      "mesh": "mesh-1",
-      "name": "tl-1",
-      "rules": [
-        {
-          "sources": [
-            {
-              "match": {
-                "service": "web",
-                "version": "1.0"
-              }
-            }
-          ],
-          "destinations": [
-            {
-              "match": {
-                "env": "dev",
-                "service": "backend"
-              }
-            }
-          ],
-          "conf": {
-            "backend": "file"
-          }
-        },
-        {
-          "sources": [
-            {
-              "match": {
-                "service": "backend"
-              }
-            }
-          ],
-          "destinations": [
-            {
-              "match": {
-                "service": "redis"
-              }
-            }
-          ]
-        }
-      ]
+     "match": {
+      "service": "backend"
+     }
     }
-  ]
+   ],
+   "mesh": "mesh-1",
+   "name": "tl-1",
+   "sources": [
+    {
+     "match": {
+      "service": "web",
+      "version": "1.0"
+     }
+    }
+   ],
+   "type": "TrafficLog"
+  }
+ ]
 }
 ```
 

--- a/docs/docs/draft/documentation/README.md
+++ b/docs/docs/draft/documentation/README.md
@@ -370,6 +370,944 @@ By default the HTTP API is listening on port `5681`. The endpoints available are
 
 You can use `GET` requests to retrieve the state of Kuma on both Universal and Kubernetes, and `PUT` and `DELETE` requests on Universal to change the state.
 
+### Meshes
+
+#### Get Mesh
+Request: `GET /meshes/{name}`
+
+Response: `200 OK` with Mesh entity
+
+Example:
+```bash
+curl http://localhost:5681/meshes/mesh-1
+```
+```json
+{
+  "name": "mesh-1",
+  "type": "Mesh",
+  "mtls": {
+    "ca": {
+      "builtin": {}
+    },
+    "enabled": true
+  },
+  "tracing": {},
+  "logging": {
+    "backends": [
+      {
+        "name": "file-tmp",
+        "format": "{ \"destination\": \"%KUMA_DESTINATION_SERVICE%\", \"destinationAddress\": \"%UPSTREAM_LOCAL_ADDRESS%\", \"source\": \"%KUMA_SOURCE_SERVICE%\", \"sourceAddress\": \"%KUMA_SOURCE_ADDRESS%\", \"bytesReceived\": \"%BYTES_RECEIVED%\", \"bytesSent\": \"%BYTES_SENT%\"}",
+        "file": {
+          "path": "/tmp/access.log"
+        }
+      },
+      {
+        "name": "logstash",
+        "tcp": {
+          "address": "logstash.internal:9000"
+        }
+      }
+    ]
+  }
+}
+```
+
+#### Create/Update Mesh
+Request: `PUT /meshes/{name}` with Mesh entity in body
+
+Response: `201 Created` when the resource is created and `200 OK` when it is updated
+
+Example:
+```bash
+curl -XPUT http://localhost:5681/meshes/mesh-1 --data @mesh.json -H'content-type: application/json'
+```
+```json
+{
+  "name": "mesh-1",
+  "type": "Mesh",
+  "mtls": {
+    "ca": {
+      "builtin": {}
+    },
+    "enabled": true
+  },
+  "tracing": {},
+  "logging": {
+    "backends": [
+      {
+        "name": "file-tmp",
+        "format": "{ \"destination\": \"%KUMA_DESTINATION_SERVICE%\", \"destinationAddress\": \"%UPSTREAM_LOCAL_ADDRESS%\", \"source\": \"%KUMA_SOURCE_SERVICE%\", \"sourceAddress\": \"%KUMA_SOURCE_ADDRESS%\", \"bytesReceived\": \"%BYTES_RECEIVED%\", \"bytesSent\": \"%BYTES_SENT%\"}",
+        "file": {
+          "path": "/tmp/access.log"
+        }
+      },
+      {
+        "name": "logstash",
+        "tcp": {
+          "address": "logstash.internal:9000"
+        }
+      }
+    ]
+  }
+}
+```
+
+#### List Meshes
+Request: `GET /meshes`
+
+Response: `200 OK` with body of Mesh entities
+
+Example:
+```bash
+curl http://localhost:5681/meshes
+```
+```json
+{
+  "items": [
+    {
+      "type": "Mesh",
+      "name": "mesh-1",
+      "mtls": {
+        "ca": {
+          "builtin": {}
+        },
+        "enabled": true
+      },
+      "tracing": {},
+      "logging": {
+        "backends": [
+          {
+            "name": "file-tmp",
+            "format": "{ \"destination\": \"%KUMA_DESTINATION_SERVICE%\", \"destinationAddress\": \"%UPSTREAM_LOCAL_ADDRESS%\", \"source\": \"%KUMA_SOURCE_SERVICE%\", \"sourceAddress\": \"%KUMA_SOURCE_ADDRESS%\", \"bytesReceived\": \"%BYTES_RECEIVED%\", \"bytesSent\": \"%BYTES_SENT%\"}",
+            "file": {
+              "path": "/tmp/access.log"
+            }
+          },
+          {
+            "name": "logstash",
+            "tcp": {
+              "address": "logstash.internal:9000"
+            }
+          }
+        ]
+      }
+    }
+  ]
+}
+```
+
+#### Delete Mesh
+Request: `DELETE /meshes/{name}`
+
+Response: `200 OK`
+
+Example:
+```bash
+curl -XDELETE http://localhost:5681/meshes/mesh-1
+```
+
+### Dataplanes
+
+#### Get Dataplane
+Request: `GET /meshes/{mesh}/dataplanes/{name}`
+
+Response: `200 OK` with Mesh entity
+
+Example:
+```bash
+curl http://localhost:5681/meshes/mesh-1/dataplanes/backend-1
+```
+```json
+{
+  "type": "Dataplane",
+  "name": "backend-1",
+  "mesh": "mesh-1",
+  "networking": {
+    "inbound": [
+      {
+        "interface": "127.0.0.1:11011:11012",
+        "tags": {
+          "service": "backend",
+          "version": "2.0",
+          "env": "production"
+        }
+      }
+    ],
+    "outbound": [
+      {
+        "interface": ":33033",
+        "service": "database"
+      },
+      {
+        "interface": ":44044",
+        "service": "user"
+      }
+    ]
+  }
+}
+```
+
+#### Create/Update Dataplane
+Request: `PUT /meshes/{mesh}/dataplanes/{name}` with Dataplane entity in body
+
+Response: `201 Created` when the resource is created and `200 OK` when it is updated
+
+Example:
+```bash
+curl -XPUT http://localhost:5681/meshes/mesh-1/dataplanes/backend-1 --data @dataplane.json -H'content-type: application/json'
+```
+```json
+{
+  "type": "Dataplane",
+  "name": "backend-1",
+  "mesh": "mesh-1",
+  "networking": {
+    "inbound": [
+      {
+        "interface": "127.0.0.1:11011:11012",
+        "tags": {
+          "service": "backend",
+          "version": "2.0",
+          "env": "production"
+        }
+      }
+    ],
+    "outbound": [
+      {
+        "interface": ":33033",
+        "service": "database"
+      },
+      {
+        "interface": ":44044",
+        "service": "user"
+      }
+    ]
+  }
+}
+```
+
+#### List Dataplanes
+Request: `GET /meshes/{mesh}/dataplanes`
+
+Response: `200 OK` with body of Dataplane entities
+
+Example:
+```bash
+curl http://localhost:5681/meshes/mesh-1/dataplanes
+```
+```json
+{
+  "items": [
+    {
+      "type": "Dataplane",
+      "name": "backend-1",
+      "mesh": "mesh-1",
+      "networking": {
+        "inbound": [
+          {
+            "interface": "127.0.0.1:11011:11012",
+            "tags": {
+              "service": "backend",
+              "version": "2.0",
+              "env": "production"
+            }
+          }
+        ],
+        "outbound": [
+          {
+            "interface": ":33033",
+            "service": "database"
+          },
+          {
+            "interface": ":44044",
+            "service": "user"
+          }
+        ]
+      }
+    }
+  ]
+}
+```
+
+#### Delete Dataplane
+Request: `DELETE /meshes/{mesh}/dataplanes/{name}`
+
+Response: `200 OK`
+
+Example:
+```bash
+curl -XDELETE http://localhost:5681/meshes/mesh-1/dataplanes/backend-1
+```
+
+### Dataplane Overviews
+
+#### Get Dataplane Overview
+Request: `GET /meshes/{mesh}/dataplane+insights/{name}`
+
+Response: `200 OK` with Dataplane entity including insight
+
+Example:
+```bash
+curl http://localhost:5681/meshes/default/dataplanes+insights/example
+```
+```json
+{
+ "type": "DataplaneOverview",
+ "mesh": "default",
+ "name": "example",
+ "dataplane": {
+  "networking": {
+   "inbound": [
+    {
+     "interface": "127.0.0.1:11011:11012",
+     "tags": {
+      "env": "production",
+      "service": "backend",
+      "version": "2.0"
+     }
+    }
+   ],
+   "outbound": [
+    {
+     "interface": ":33033",
+     "service": "database"
+    }
+   ]
+  }
+ },
+ "dataplaneInsight": {
+  "subscriptions": [
+   {
+    "id": "426fe0d8-f667-11e9-b081-acde48001122",
+    "controlPlaneInstanceId": "06070748-f667-11e9-b081-acde48001122",
+    "connectTime": "2019-10-24T14:04:56.820350Z",
+    "status": {
+     "lastUpdateTime": "2019-10-24T14:04:57.832482Z",
+     "total": {
+      "responsesSent": "3",
+      "responsesAcknowledged": "3"
+     },
+     "cds": {
+      "responsesSent": "1",
+      "responsesAcknowledged": "1"
+     },
+     "eds": {
+      "responsesSent": "1",
+      "responsesAcknowledged": "1"
+     },
+     "lds": {
+      "responsesSent": "1",
+      "responsesAcknowledged": "1"
+     },
+     "rds": {}
+    }
+   }
+  ]
+ }
+}
+```
+
+#### List Dataplane Overviews
+Request: `GET /meshes/{mesh}/dataplane+insights/`
+
+Response: `200 OK` with Dataplane entities including insight
+
+Example:
+```bash
+curl http://localhost:5681/meshes/default/dataplanes+insights
+```
+```json
+{
+  "items": [
+    {
+     "type": "DataplaneOverview",
+     "mesh": "default",
+     "name": "example",
+     "dataplane": {
+      "networking": {
+       "inbound": [
+        {
+         "interface": "127.0.0.1:11011:11012",
+         "tags": {
+          "env": "production",
+          "service": "backend",
+          "version": "2.0"
+         }
+        }
+       ],
+       "outbound": [
+        {
+         "interface": ":33033",
+         "service": "database"
+        }
+       ]
+      }
+     },
+     "dataplaneInsight": {
+      "subscriptions": [
+       {
+        "id": "426fe0d8-f667-11e9-b081-acde48001122",
+        "controlPlaneInstanceId": "06070748-f667-11e9-b081-acde48001122",
+        "connectTime": "2019-10-24T14:04:56.820350Z",
+        "status": {
+         "lastUpdateTime": "2019-10-24T14:04:57.832482Z",
+         "total": {
+          "responsesSent": "3",
+          "responsesAcknowledged": "3"
+         },
+         "cds": {
+          "responsesSent": "1",
+          "responsesAcknowledged": "1"
+         },
+         "eds": {
+          "responsesSent": "1",
+          "responsesAcknowledged": "1"
+         },
+         "lds": {
+          "responsesSent": "1",
+          "responsesAcknowledged": "1"
+         },
+         "rds": {}
+        }
+       }
+      ]
+     }
+    }
+  ]
+}
+```
+
+### Proxy Template
+
+#### Get Proxy Template
+Request: `GET /meshes/{mesh}/proxytemplates/{name}`
+
+Response: `200 OK` with Proxy Template entity
+
+Example:
+```bash
+curl http://localhost:5681/meshes/mesh-1/proxytemplates/pt-1
+```
+```json
+{
+  "type": "ProxyTemplate",
+  "name": "pt-1",
+  "mesh": "mesh-1",
+  "selectors": [
+    {
+      "match": {
+          "app": "backend"
+      }
+    }
+  ],
+  "imports": [
+    "default-proxy"
+  ],
+  "resources": [
+    {
+      "name": "raw-name",
+      "version": "raw-version",
+      "resource": "'@type': type.googleapis.com/envoy.api.v2.Cluster\nconnectTimeout: 5s\nloadAssignment:\n  clusterName: localhost:8443\n  endpoints:\n    - lbEndpoints:\n        - endpoint:\n            address:\n              socketAddress:\n                address: 127.0.0.1\n                portValue: 8443\nname: localhost:8443\ntype: STATIC\n"
+    }
+  ]
+}
+```
+
+#### Create/Update Proxy Template
+Request: `PUT /meshes/{mesh}/proxytemplates/{name}` with Proxy Template entity in body
+
+Response: `201 Created` when the resource is created and `200 OK` when it is updated
+
+Example:
+```bash
+curl -XPUT http://localhost:5681/meshes/mesh-1/proxytemplates/pt-1 --data @proxytemplate.json -H'content-type: application/json'
+```
+```json
+{
+  "type": "ProxyTemplate",
+  "name": "pt-1",
+  "mesh": "mesh-1",
+  "selectors": [
+    {
+      "match": {
+          "app": "backend"
+      }
+    }
+  ],
+  "imports": [
+    "default-proxy"
+  ],
+  "resources": [
+    {
+      "name": "raw-name",
+      "version": "raw-version",
+      "resource": "'@type': type.googleapis.com/envoy.api.v2.Cluster\nconnectTimeout: 5s\nloadAssignment:\n  clusterName: localhost:8443\n  endpoints:\n    - lbEndpoints:\n        - endpoint:\n            address:\n              socketAddress:\n                address: 127.0.0.1\n                portValue: 8443\nname: localhost:8443\ntype: STATIC\n"
+    }
+  ]
+}
+```
+
+#### List Proxy Templates
+Request: `GET /meshes/{mesh}/proxytemplates`
+
+Response: `200 OK` with body of Proxy Template entities
+
+Example:
+```bash
+curl http://localhost:5681/meshes/mesh-1/proxytemplates
+```
+```json
+{
+  "items": [
+    {
+      "type": "ProxyTemplate",
+      "name": "pt-1",
+      "mesh": "mesh-1",
+      "selectors": [
+        {
+          "match": {
+              "app": "backend"
+          }
+        }
+      ],
+      "imports": [
+        "default-proxy"
+      ],
+      "resources": [
+        {
+          "name": "raw-name",
+          "version": "raw-version",
+          "resource": "'@type': type.googleapis.com/envoy.api.v2.Cluster\nconnectTimeout: 5s\nloadAssignment:\n  clusterName: localhost:8443\n  endpoints:\n    - lbEndpoints:\n        - endpoint:\n            address:\n              socketAddress:\n                address: 127.0.0.1\n                portValue: 8443\nname: localhost:8443\ntype: STATIC\n"
+        }
+      ]
+    }
+  ]
+}
+```
+
+#### Delete Proxy Template
+Request: `DELETE /meshes/{mesh}/proxytemplates/{name}`
+
+Response: `200 OK`
+
+Example:
+```bash
+curl -XDELETE http://localhost:5681/meshes/mesh-1/proxytemplates/pt-1
+```
+
+### Traffic Permission
+
+#### Get Traffic Permission
+Request: `GET /meshes/{mesh}/traffic-permissions/{name}`
+
+Response: `200 OK` with Traffic Permission entity
+
+Example:
+```bash
+curl http://localhost:5681/meshes/mesh-1/traffic-permissions/tp-1
+```
+```json
+{
+  "type": "TrafficPermission",
+  "name": "tp-1",
+  "mesh": "mesh-1",
+  "rules": [
+    {
+      "sources": [
+        {
+          "match": {
+            "service": "web"
+          }
+        }
+      ],
+      "destinations": [
+        {
+          "match": {
+            "service": "backend"
+          }
+        }
+      ]
+    },
+    {
+      "sources": [
+        {
+          "match": {
+            "service": "backend",
+            "version": "1"
+          }
+        }
+      ],
+      "destinations": [
+        {
+          "match": {
+            "service": "redis",
+            "version": "1"
+          }
+        }
+      ]
+    },
+    {
+      "sources": [
+        {
+          "match": {
+            "service": "backend",
+            "version": "2"
+          }
+        }
+      ],
+      "destinations": [
+        {
+          "match": {
+            "service": "redis",
+            "version": "2"
+          }
+        }
+      ]
+    }
+  ]
+}
+```
+
+#### Create/Update Traffic Permission
+Request: `PUT /meshes/{mesh}/trafficpermissions/{name}` with Traffic Permission entity in body
+
+Response: `201 Created` when the resource is created and `200 OK` when it is updated
+
+Example:
+```bash
+curl -XPUT http://localhost:5681/meshes/mesh-1/traffic-permissions/tp-1 --data @trafficpermission.json -H'content-type: application/json'
+```
+```json
+{
+  "type": "TrafficPermission",
+  "name": "tp-1",
+  "mesh": "mesh-1",
+  "rules": [
+    {
+      "sources": [
+        {
+          "match": {
+            "service": "web"
+          }
+        }
+      ],
+      "destinations": [
+        {
+          "match": {
+            "service": "backend"
+          }
+        }
+      ]
+    },
+    {
+      "sources": [
+        {
+          "match": {
+            "service": "backend",
+            "version": "1"
+          }
+        }
+      ],
+      "destinations": [
+        {
+          "match": {
+            "service": "redis",
+            "version": "1"
+          }
+        }
+      ]
+    },
+    {
+      "sources": [
+        {
+          "match": {
+            "service": "backend",
+            "version": "2"
+          }
+        }
+      ],
+      "destinations": [
+        {
+          "match": {
+            "service": "redis",
+            "version": "2"
+          }
+        }
+      ]
+    }
+  ]
+}
+```
+
+#### List Traffic Permissions
+Request: `GET /meshes/{mesh}/traffic-permissions`
+
+Response: `200 OK` with body of Traffic Permission entities
+
+Example:
+```bash
+curl http://localhost:5681/meshes/mesh-1/traffic-permissions
+```
+```json
+{
+  "items": [
+    {
+      "type": "TrafficPermission",
+      "name": "tp-1",
+      "mesh": "mesh-1",
+      "rules": [
+        {
+          "sources": [
+            {
+              "match": {
+                "service": "web"
+              }
+            }
+          ],
+          "destinations": [
+            {
+              "match": {
+                "service": "backend"
+              }
+            }
+          ]
+        },
+        {
+          "sources": [
+            {
+              "match": {
+                "service": "backend",
+                "version": "1"
+              }
+            }
+          ],
+          "destinations": [
+            {
+              "match": {
+                "service": "redis",
+                "version": "1"
+              }
+            }
+          ]
+        },
+        {
+          "sources": [
+            {
+              "match": {
+                "service": "backend",
+                "version": "2"
+              }
+            }
+          ],
+          "destinations": [
+            {
+              "match": {
+                "service": "redis",
+                "version": "2"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+```
+
+#### Delete Traffic Permission
+Request: `DELETE /meshes/{mesh}/traffic-permissions/{name}`
+
+Response: `200 OK`
+
+Example:
+```bash
+curl -XDELETE http://localhost:5681/meshes/mesh-1/traffic-permissions/pt-1
+```
+
+### Traffic Log
+
+#### Get Traffic Log
+Request: `GET /meshes/{mesh}/traffic-logs/{name}`
+
+Response: `200 OK` with Traffic Log entity
+
+Example:
+```bash
+curl http://localhost:5681/meshes/mesh-1/traffic-logs/tl-1
+```
+```json
+{
+  "type": "TrafficLog",
+  "mesh": "mesh-1",
+  "name": "tl-1",
+  "rules": [
+    {
+      "sources": [
+        {
+          "match": {
+            "service": "web",
+            "version": "1.0"
+          }
+        }
+      ],
+      "destinations": [
+        {
+          "match": {
+            "env": "dev",
+            "service": "backend"
+          }
+        }
+      ],
+      "conf": {
+        "backend": "file"
+      }
+    },
+    {
+      "sources": [
+        {
+          "match": {
+            "service": "backend"
+          }
+        }
+      ],
+      "destinations": [
+        {
+          "match": {
+            "service": "redis"
+          }
+        }
+      ]
+    }
+  ]
+}
+```
+
+#### Create/Update Traffic Log
+Request: `PUT /meshes/{mesh}/traffic-logs/{name}` with Traffic Log entity in body
+
+Response: `201 Created` when the resource is created and `200 OK` when it is updated
+
+Example:
+```bash
+curl -XPUT http://localhost:5681/meshes/mesh-1/traffic-logs/tl-1 --data @trafficlog.json -H'content-type: application/json'
+```
+```json
+{
+  "type": "TrafficLog",
+  "mesh": "mesh-1",
+  "name": "tl-1",
+  "rules": [
+    {
+      "sources": [
+        {
+          "match": {
+            "service": "web",
+            "version": "1.0"
+          }
+        }
+      ],
+      "destinations": [
+        {
+          "match": {
+            "env": "dev",
+            "service": "backend"
+          }
+        }
+      ],
+      "conf": {
+        "backend": "file"
+      }
+    },
+    {
+      "sources": [
+        {
+          "match": {
+            "service": "backend"
+          }
+        }
+      ],
+      "destinations": [
+        {
+          "match": {
+            "service": "redis"
+          }
+        }
+      ]
+    }
+  ]
+}
+```
+
+#### List Traffic Logs
+Request: `GET /meshes/{mesh}/traffic-logs`
+
+Response: `200 OK` with body of Traffic Log entities
+
+Example:
+```bash
+curl http://localhost:5681/meshes/mesh-1/traffic-logs
+```
+```json
+{
+  "items": [
+    {
+      "type": "TrafficLog",
+      "mesh": "mesh-1",
+      "name": "tl-1",
+      "rules": [
+        {
+          "sources": [
+            {
+              "match": {
+                "service": "web",
+                "version": "1.0"
+              }
+            }
+          ],
+          "destinations": [
+            {
+              "match": {
+                "env": "dev",
+                "service": "backend"
+              }
+            }
+          ],
+          "conf": {
+            "backend": "file"
+          }
+        },
+        {
+          "sources": [
+            {
+              "match": {
+                "service": "backend"
+              }
+            }
+          ],
+          "destinations": [
+            {
+              "match": {
+                "service": "redis"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+```
+
+#### Delete Traffic Log
+Request: `DELETE /meshes/{mesh}/traffic-logs/{name}`
+
+Response: `200 OK`
+
+Example:
+```bash
+curl -XDELETE http://localhost:5681/meshes/mesh-1/traffic-logs/tl-1
+```
+
 ::: tip
 The [`kumactl`](/kumactl) CLI under the hood makes HTTP requests to this API.
 :::

--- a/docs/docs/draft/policies/README.md
+++ b/docs/docs/draft/policies/README.md
@@ -121,14 +121,13 @@ On Universal:
 type: TrafficPermission
 name: permission-1
 mesh: default
-rules:
-  - sources:
-      - match:
-          service: backend
-    destinations:
-      - match:
-          service: redis
-          version: "5.0"
+sources:
+  - match:
+      service: backend
+destinations:
+  - match:
+      service: redis
+      version: '5.0'
 ```
 
 On Kubernetes:
@@ -141,18 +140,17 @@ metadata:
   namespace: default
   name: permission-1
 spec:
-  rules:
-    - sources:
-        - match:
-            service: backend
-      destinations:
-        - match:
-            service: redis
-            version: "5.0"
+  sources:
+    - match:
+        service: backend
+  destinations:
+    - match:
+        service: redis
+        version: '5.0'
 ```
 
 ::: tip
-**Match-All**: You can match any value of a tag by using `*`, like `version: *`.
+**Match-All**: You can match any value of a tag by using `*`, like `version: '*'`.
 :::
 
 ## Traffic Route
@@ -169,22 +167,21 @@ On Universal:
 type: TrafficRoute
 name: route-1
 mesh: default
-rules:
-  - sources:
-      - match:
-          service: backend
-    destinations:
-      - match:
-          service: redis
-    conf:
-      - weight: 90
-        destination:
-          - service: redis
-            version: "1.0"
-      - weight: 10
-        destination:
-          - service: redis
-            version: "2.0"
+sources:
+  - match:
+      service: backend
+destinations:
+  - match:
+      service: redis
+conf:
+  - weight: 90
+    destination:
+      service: redis
+      version: '1.0'
+  - weight: 10
+    destination:
+      service: redis
+      version: '2.0'
 ```
 
 On Kubernetes:
@@ -197,22 +194,21 @@ metadata:
   namespace: default
   name: route-1
 spec:
-  rules:
-    - sources:
-      - match:
-          service: backend
-    destinations:
-      - match:
-          service: redis
-    conf:
-      - weight: 90
-        destination:
-          - service: redis
-            version: "1.0"
-      - weight: 10
-        destination:
-          - service: redis
-            version: "2.0"
+  sources:
+  - match:
+      service: backend
+  destinations:
+  - match:
+      service: redis
+  conf:
+    - weight: 90
+      destination:
+        service: redis
+        version: '1.0'
+    - weight: 10
+      destination:
+        service: redis
+        version: '2.0'
 ```
 
 ## Traffic Tracing
@@ -257,8 +253,8 @@ The first step is to configure backends for the `Mesh`. A backend can be either 
 On Universal:
 
 ```yaml
-name: default
 type: Mesh
+name: default
 mtls:
   ca:
     builtin: {}
@@ -284,24 +280,30 @@ logging:
 ```
 
 ```yaml
-name: log-rule
-mesh: default
 type: TrafficLog
-rules:
-  - sources:
-    - match:
-        service: backend
-    destinations:
-    - match:
-        service: database
-    conf:
-      backend: logstash
-  - sources:
-    - match:
-        service: *
-    destinations:
-    - match:
-        service: *
+name: all-traffic
+mesh: default
+sources:
+- match:
+    service: '*'
+destinations:
+- match:
+    service: '*'
+# if omitted, the default logging backend of that mesh will be used
+```
+
+```yaml
+type: TrafficLog
+name: backend-to-database-traffic
+mesh: default
+sources:
+- match:
+    service: backend
+destinations:
+- match:
+    service: database
+conf:
+  backend: logstash
 ```
 
 On Kubernetes:
@@ -342,23 +344,32 @@ apiVersion: kuma.io/v1alpha1
 kind: TrafficLog
 metadata:
   namespace: kuma-system
-  name: log-rule
+  name: all-traffic
 spec:
-  rules:
-    - sources:
-      - match:
-          service: backend
-      destinations:
-      - match:
-          service: database
-      conf:
-        backend: logstash
-    - sources:
-      - match:
-          service: *
-      destinations:
-      - match:
-          service: *
+  sources:
+  - match:
+      service: '*'
+  destinations:
+  - match:
+      service: '*'
+  # if omitted, the default logging backend of that mesh will be used
+```
+
+```yaml
+apiVersion: kuma.io/v1alpha1
+kind: TrafficLog
+metadata:
+  namespace: kuma-system
+  name: backend-to-database-traffic
+spec:
+  sources:
+  - match:
+      service: backend
+  destinations:
+  - match:
+      service: database
+  conf:
+    backend: logstash
 ```
 
 ::: tip
@@ -406,21 +417,22 @@ mesh: default
 metadata:
   namespace: default
   name: template-1
-selectors:
-  - match:
-      service: backend
-conf:
-  imports:
-    - default-proxy
-  resources:
-    - ..
-    - ..
+spec:
+  selectors:
+    - match:
+        service: backend
+  conf:
+    imports:
+      - default-proxy
+    resources:
+      - ..
+      - ..
 ```
 
 Below you can find an example of what a `ProxyTemplate` configuration could look like:
 
 ```yaml
-imports:
+  imports:
     - default-proxy
   resources:
     - name: localhost:9901
@@ -456,11 +468,11 @@ imports:
                 virtual_hosts:
                 - routes:
                   - match:
-                      prefix: "/stats/prometheus"
+                      prefix: /stats/prometheus
                     route:
                       cluster: localhost:9901
                   domains:
-                  - "*"
+                  - '*'
                   name: envoy_admin
               codec_type: AUTO
               http_filters:


### PR DESCRIPTION
### Summary

*  update configuration examples for `TrafficPermission` and `TrafficRoute` (`rules` field has been removed)
* update configuration examples for `ProxyTemplate` (to be in sync with actual implementation)
* fix invalid configuration examples
* update REST API examples