### PR TITLE
docs(readme) port on which Kuma GUI is exposed

### DIFF
--- a/docs/docs/draft/documentation/README.md
+++ b/docs/docs/draft/documentation/README.md
@@ -1405,6 +1405,7 @@ When `kuma-cp` starts up, by default it listens on a few ports:
 * `5680`: the HTTP server that returns the health status of the control-plane.
 * `5681`: the HTTP API server that is being used by `kumactl`, and that you can also use to retrieve Kuma's policies and - when runnning in `universal` - that you can use to apply new policies.
 * `5682`: the HTTP server that provides the Envoy bootstrap configuration when the data-plane starts up.
+* `5683`: the HTTP server that exposes Kuma UI.
 
 ## Quickstart
 


### PR DESCRIPTION
Is this enough? I think it's worth do describe UI with a screen or two once we've got it working in our release.