### PR TITLE
Newsletter Pardot Handler redirect static pages

### DIFF
--- a/bin/setup-redirects/index.js
+++ b/bin/setup-redirects/index.js
@@ -20,6 +20,14 @@ to = "/docs/${latest}/"
 status = 301
 force = false
 
+# Newsletter Pardot form queries
+[[redirects]]
+from = "/*"
+query = {form_success = ":value"}
+to = "/?form_success=:value"
+status = 301
+force = false
+
 # Install redirect
 [[redirects]]
 from = "/install/"

--- a/docs/.vuepress/theme/components/custom/Community.vue
+++ b/docs/.vuepress/theme/components/custom/Community.vue
@@ -4,7 +4,7 @@
     <header v-if="$page.frontmatter.title" class="page-header text-center bg-gradient">
       <div class="inner">
         <h1>{{ $page.frontmatter.title }}</h1>
-        <p v-if="$page.frontmatter.title" class="page-sub-title">{{ $page.frontmatter.subTitle }}</p>
+        <p v-if="$page.frontmatter.subTitle" class="page-sub-title">{{ $page.frontmatter.subTitle }}</p>
       </div>
       <!-- .inner -->
     </header>

--- a/docs/.vuepress/theme/components/custom/RequestADemo.vue
+++ b/docs/.vuepress/theme/components/custom/RequestADemo.vue
@@ -4,7 +4,7 @@
     <header v-if="$page.frontmatter.pageTitle" class="page-header text-center bg-gradient">
       <div class="inner">
         <h1>{{ $page.frontmatter.pageTitle }}</h1>
-        <p v-if="$page.frontmatter.pageTitle" class="page-sub-title">{{ $page.frontmatter.subTitle }}</p>
+        <p v-if="$page.frontmatter.subTitle" class="page-sub-title">{{ $page.frontmatter.subTitle }}</p>
       </div>
       <!-- .inner -->
     </header>

--- a/docs/.vuepress/theme/components/custom/Shell.vue
+++ b/docs/.vuepress/theme/components/custom/Shell.vue
@@ -1,0 +1,29 @@
+<template>
+  <div class="page-container page-container--community">
+
+    <header v-if="$page.frontmatter.title" class="page-header text-center bg-gradient">
+      <div class="inner">
+        <h1>{{ $page.frontmatter.title }}</h1>
+        <p v-if="$page.frontmatter.subTitle" class="page-sub-title">{{ $page.frontmatter.subTitle }}</p>
+      </div>
+      <!-- .inner -->
+    </header>
+    <!-- .page-header -->
+
+    <div class="inner flex flex-wrap -mx-4">
+      <Content />
+    </div>
+    <!-- .inner -->
+  
+  </div>
+</template>
+
+<script>
+export default {
+  
+}
+</script>
+
+<style lang="scss">
+
+</style>

--- a/docs/.vuepress/theme/layouts/Layout.vue
+++ b/docs/.vuepress/theme/layouts/Layout.vue
@@ -51,6 +51,9 @@ import Page from '@theme/components/Page.vue'
 import Sidebar from '@theme/components/Sidebar.vue'
 import { resolveSidebarItems, redirectToLatestVersion } from '../util'
 
+// reusable page template
+import Shell from '@theme/components/custom/Shell.vue'
+
 // specific page templates
 import Home from '@theme/components/custom/Home.vue'
 import Install from '@theme/components/custom/Install.vue'
@@ -63,6 +66,7 @@ export default {
     Page,
     Sidebar,
     Navbar,
+    Shell,
     Home,
     Install,
     Community,

--- a/docs/newsletter/error.md
+++ b/docs/newsletter/error.md
@@ -1,0 +1,6 @@
+---
+sidebar: false
+title: Error!
+subTitle: There was an error submitting your newsletter subscription. Please try again later.
+layout: Shell
+---

--- a/docs/newsletter/thank-you.md
+++ b/docs/newsletter/thank-you.md
@@ -1,0 +1,6 @@
+---
+sidebar: false
+title: Thank you!
+subTitle: Your newsletter subscription has been received. Thank you for your interest in Kuma!
+layout: Shell
+---


### PR DESCRIPTION
Since Netlify doesn't play nice with Vue and throws 404 pages with URL queries, this change adds static thank you and failure pages for the newsletter form. this is a foolproof workaround that will work correctly with SalesForce Pardot.

### The issue
- When redirecting back from the Pardot handler, URLs like `/?form_success=true` and `/?form_success=false` will send the user to a 404 page
- If you refresh these pages, the correct behavior occurs (the user is sent to the newsletter form on the homepage, and they are presented with a failure or success message below the form)

### The solution
Netlify has methods for handling redirects but from my experience, nothing solved this issue. So the easiest solution is to create static pages on the site for both failed and successful submissions. The alternative is to change vue-router to its default behavior instead of History mode, but this is more problematic since we already have a lot of established clean URLs.