### PR TITLE
404 error fixes

### DIFF
--- a/docs/docs/0.2.2/installation/centos.md
+++ b/docs/docs/0.2.2/installation/centos.md
@@ -103,7 +103,7 @@ $ kumactl config control-planes add --name=XYZ --address=http://address.to.kuma:
 
 If you consume the service again on port `10000`, you will now notice that the communication requires now a TLS connection.
 
-You can now review the entities created by Kuma by using the [`kumactl`](/docs/0.2.2/documentation/#kumactl) CLI. For example you can list the Meshes:
+You can now review the entities created by Kuma by using the [`kumactl`](/docs/0.2.2/documentation/kumactl) CLI. For example you can list the Meshes:
 
 ```sh
 $ kumactl get meshes

--- a/docs/docs/0.2.2/policies/applying-policies.md
+++ b/docs/docs/0.2.2/policies/applying-policies.md
@@ -1,6 +1,6 @@
 # Applying Policies
 
-Once installed, Kuma can be configured via its policies. You can apply policies with [`kumactl`](/docs/0.2.2/documentation/#kumactl) on Universal, and with `kubectl` on Kubernetes. Regardless of what environment you use, you can always read the latest Kuma state with [`kumactl`](/docs/0.2.2/documentation/#kumactl) on both environments.
+Once installed, Kuma can be configured via its policies. You can apply policies with [`kumactl`](/docs/0.2.2/documentation/kumactl) on Universal, and with `kubectl` on Kubernetes. Regardless of what environment you use, you can always read the latest Kuma state with [`kumactl`](/docs/0.2.2/documentation/kumactl) on both environments.
 
 ::: tip
 We follow the best practices. You should always change your Kubernetes state with CRDs, that's why Kuma disables `kumactl apply [..]` when running in K8s environments.
@@ -25,4 +25,4 @@ echo "
 " | kubectl apply -f -
 ```
 
-Below you can find the policies that Kuma supports. In addition to [`kumactl`](/docs/0.2.2/documentation/#kumactl), you can also retrive the state via the Kuma [HTTP API](/docs/0.2.2/documentation/#http-api) as well.
+Below you can find the policies that Kuma supports. In addition to [`kumactl`](/docs/0.2.2/documentation/kumactl), you can also retrive the state via the Kuma [HTTP API](/docs/0.2.2/documentation/#http-api) as well.

--- a/docs/docs/0.3.0/policies/applying-policies.md
+++ b/docs/docs/0.3.0/policies/applying-policies.md
@@ -1,6 +1,6 @@
 # Applying Policies
 
-Once installed, Kuma can be configured via its policies. You can apply policies with [`kumactl`](/docs/0.3.0/documentation/#kumactl) on Universal, and with `kubectl` on Kubernetes. Regardless of what environment you use, you can always read the latest Kuma state with [`kumactl`](/docs/0.3.0/documentation/#kumactl) on both environments.
+Once installed, Kuma can be configured via its policies. You can apply policies with [`kumactl`](/docs/0.3.0/documentation/kumactl) on Universal, and with `kubectl` on Kubernetes. Regardless of what environment you use, you can always read the latest Kuma state with [`kumactl`](/docs/0.3.0/documentation/kumactl) on both environments.
 
 ::: tip
 We follow the best practices. You should always change your Kubernetes state with CRDs, that's why Kuma disables `kumactl apply [..]` when running in K8s environments.
@@ -25,4 +25,4 @@ echo "
 " | kubectl apply -f -
 ```
 
-Below you can find the policies that Kuma supports. In addition to [`kumactl`](/docs/0.3.0/documentation/#kumactl), you can also retrive the state via the Kuma [HTTP API](/docs/0.3.0/documentation/#http-api) as well.
+Below you can find the policies that Kuma supports. In addition to [`kumactl`](/docs/0.3.0/documentation/kumactl), you can also retrive the state via the Kuma [HTTP API](/docs/0.3.0/documentation/#http-api) as well.

--- a/docs/docs/0.3.1/policies/applying-policies.md
+++ b/docs/docs/0.3.1/policies/applying-policies.md
@@ -1,6 +1,6 @@
 # Applying Policies
 
-Once installed, Kuma can be configured via its policies. You can apply policies with [`kumactl`](/docs/0.3.1/documentation/#kumactl) on Universal, and with `kubectl` on Kubernetes. Regardless of what environment you use, you can always read the latest Kuma state with [`kumactl`](/docs/0.3.1/documentation/#kumactl) on both environments.
+Once installed, Kuma can be configured via its policies. You can apply policies with [`kumactl`](/docs/0.3.1/documentation/kumactl) on Universal, and with `kubectl` on Kubernetes. Regardless of what environment you use, you can always read the latest Kuma state with [`kumactl`](/docs/0.3.1/documentation/kumactl) on both environments.
 
 ::: tip
 We follow the best practices. You should always change your Kubernetes state with CRDs, that's why Kuma disables `kumactl apply [..]` when running in K8s environments.
@@ -25,4 +25,4 @@ echo "
 " | kubectl apply -f -
 ```
 
-Below you can find the policies that Kuma supports. In addition to [`kumactl`](/docs/0.3.1/documentation/#kumactl), you can also retrive the state via the Kuma [HTTP API](/docs/0.3.1/documentation/#http-api) as well.
+Below you can find the policies that Kuma supports. In addition to [`kumactl`](/docs/0.3.1/documentation/kumactl), you can also retrive the state via the Kuma [HTTP API](/docs/0.3.1/documentation/#http-api) as well.

--- a/docs/docs/0.3.2/overview/enabling-modernization.md
+++ b/docs/docs/0.3.2/overview/enabling-modernization.md
@@ -1,0 +1,15 @@
+# Enabling Modernization
+
+Until now, Service Mesh has been considered to be the last step of architecture modernization after transitioning to containers and perhaps to Kubernetes. This approach is entirely backwards. It makes the adoption and the business value of Service Mesh available only after implementing other massive transformations that—in the meanwhile—can go wrong.
+
+In reality, we want Service Mesh to be available *before* we implement other transitions so that we can keep the network both secure and observable in the process. With Kuma, Service Mesh is indeed the **first step** towards modernization.
+
+<center>
+<img src="/images/docs/0.2.0/diagram-05.jpg" alt="" style=" padding-top: 20px; padding-bottom: 10px;"/>
+</center>
+
+Unlike other control planes, Kuma natively runs across any platform, and it's not limited in scope (i.e., Kubernetes only). Kuma works on both existing brownfield applications (those apps that deliver business value today), as well as new and modern greenfield applications that will be the future of our journey.
+
+Unlike other control planes, Kuma is easy to use. Anybody - from any team - can implement Kuma in [three simple steps](/install/0.3.2) across both traditional monolithic applications and modern microservices.
+
+Finally, by leveraging out-of-the-box policies and Kuma's powerful tagging selectors, we can implement a variety of behaviors in a variety of topologies, similar to multi-cloud and multi-region architectures.

--- a/docs/docs/0.3.2/policies/README.md
+++ b/docs/docs/0.3.2/policies/README.md
@@ -8,7 +8,7 @@ Here you can find the list of Policies that Kuma supports, that will allow you t
 
 ## Applying Policies
 
-Once installed, Kuma can be configured via its policies. You can apply policies with [`kumactl`](/docs/0.3.2/documentation/#kumactl) on Universal, and with `kubectl` on Kubernetes. Regardless of what environment you use, you can always read the latest Kuma state with [`kumactl`](/docs/0.3.2/documentation/#kumactl) on both environments.
+Once installed, Kuma can be configured via its policies. You can apply policies with [`kumactl`](/docs/0.3.2/documentation/kumactl) on Universal, and with `kubectl` on Kubernetes. Regardless of what environment you use, you can always read the latest Kuma state with [`kumactl`](/docs/0.3.2/documentation/kumactl) on both environments.
 
 ::: tip
 We follow the best practices. You should always change your Kubernetes state with CRDs, that's why Kuma disables `kumactl apply [..]` when running in K8s environments.
@@ -33,7 +33,7 @@ echo "
 " | kubectl apply -f -
 ```
 
-Below you can find the policies that Kuma supports. In addition to [`kumactl`](/docs/0.3.2/documentation/#kumactl), you can also retrive the state via the Kuma [HTTP API](/docs/0.3.2/documentation/#http-api) as well.
+Below you can find the policies that Kuma supports. In addition to [`kumactl`](/docs/0.3.2/documentation/kumactl), you can also retrive the state via the Kuma [HTTP API](/docs/0.3.2/documentation/#http-api) as well.
 
 ## Mesh
 

--- a/docs/docs/0.3.2/policies/applying-policies.md
+++ b/docs/docs/0.3.2/policies/applying-policies.md
@@ -1,6 +1,6 @@
 # Applying Policies
 
-Once installed, Kuma can be configured via its policies. You can apply policies with [`kumactl`](/docs/0.3.2/documentation/#kumactl) on Universal, and with `kubectl` on Kubernetes. Regardless of what environment you use, you can always read the latest Kuma state with [`kumactl`](/docs/0.3.2/documentation/#kumactl) on both environments.
+Once installed, Kuma can be configured via its policies. You can apply policies with [`kumactl`](/docs/0.3.2/documentation/kumactl) on Universal, and with `kubectl` on Kubernetes. Regardless of what environment you use, you can always read the latest Kuma state with [`kumactl`](/docs/0.3.2/documentation/kumactl) on both environments.
 
 ::: tip
 We follow the best practices. You should always change your Kubernetes state with CRDs, that's why Kuma disables `kumactl apply [..]` when running in K8s environments.
@@ -25,4 +25,4 @@ echo "
 " | kubectl apply -f -
 ```
 
-Below you can find the policies that Kuma supports. In addition to [`kumactl`](/docs/0.3.2/documentation/#kumactl), you can also retrive the state via the Kuma [HTTP API](/docs/0.3.2/documentation/#http-api) as well.
+Below you can find the policies that Kuma supports. In addition to [`kumactl`](/docs/0.3.2/documentation/kumactl), you can also retrive the state via the Kuma [HTTP API](/docs/0.3.2/documentation/#http-api) as well.

--- a/docs/docs/draft/policies/README.md
+++ b/docs/docs/draft/policies/README.md
@@ -8,7 +8,7 @@ Here you can find the list of Policies that Kuma supports, that will allow you t
 
 ## Applying Policies
 
-Once installed, Kuma can be configured via its policies. You can apply policies with [`kumactl`](/docs/DRAFT/documentation/#kumactl) on Universal, and with `kubectl` on Kubernetes. Regardless of what environment you use, you can always read the latest Kuma state with [`kumactl`](/docs/DRAFT/documentation/#kumactl) on both environments.
+Once installed, Kuma can be configured via its policies. You can apply policies with [`kumactl`](/docs/DRAFT/documentation/kumactl) on Universal, and with `kubectl` on Kubernetes. Regardless of what environment you use, you can always read the latest Kuma state with [`kumactl`](/docs/DRAFT/documentation/kumactl) on both environments.
 
 ::: tip
 We follow the best practices. You should always change your Kubernetes state with CRDs, that's why Kuma disables `kumactl apply [..]` when running in K8s environments.
@@ -33,7 +33,7 @@ echo "
 " | kubectl apply -f -
 ```
 
-Below you can find the policies that Kuma supports. In addition to [`kumactl`](/docs/DRAFT/documentation/#kumactl), you can also retrive the state via the Kuma [HTTP API](/docs/DRAFT/documentation/#http-api) as well.
+Below you can find the policies that Kuma supports. In addition to [`kumactl`](/docs/DRAFT/documentation/kumactl), you can also retrive the state via the Kuma [HTTP API](/docs/DRAFT/documentation/#http-api) as well.
 
 ## Mesh
 

--- a/docs/docs/draft/policies/applying-policies.md
+++ b/docs/docs/draft/policies/applying-policies.md
@@ -1,6 +1,6 @@
 # Applying Policies
 
-Once installed, Kuma can be configured via its policies. You can apply policies with [`kumactl`](/docs/0.3.2/documentation/#kumactl) on Universal, and with `kubectl` on Kubernetes. Regardless of what environment you use, you can always read the latest Kuma state with [`kumactl`](/docs/0.3.2/documentation/#kumactl) on both environments.
+Once installed, Kuma can be configured via its policies. You can apply policies with [`kumactl`](/docs/0.3.2/documentation/kumactl) on Universal, and with `kubectl` on Kubernetes. Regardless of what environment you use, you can always read the latest Kuma state with [`kumactl`](/docs/0.3.2/documentation/kumactl) on both environments.
 
 ::: tip
 We follow the best practices. You should always change your Kubernetes state with CRDs, that's why Kuma disables `kumactl apply [..]` when running in K8s environments.
@@ -25,4 +25,4 @@ echo "
 " | kubectl apply -f -
 ```
 
-Below you can find the policies that Kuma supports. In addition to [`kumactl`](/docs/0.3.2/documentation/#kumactl), you can also retrive the state via the Kuma [HTTP API](/docs/0.3.2/documentation/#http-api) as well.
+Below you can find the policies that Kuma supports. In addition to [`kumactl`](/docs/0.3.2/documentation/kumactl), you can also retrive the state via the Kuma [HTTP API](/docs/0.3.2/documentation/#http-api) as well.


### PR DESCRIPTION
Fixed the listed 404s:

- https://kuma.io/docs/0.3.2/overview/enabling-modernization - Text: "Learn more"
- https://kuma.io/docs/0.3.2/documentation/ - Text: "kumactl"

This link needs to be reviewed and either removed or updated with the most recent page available from the Envoy website:
- https://www.envoyproxy.io/docs/envoy/latest/configuration/overview/v2_overview - Text: xDS (found in the `/documentation/overview.md` file of each version)

