### PR TITLE
Old URL redirects

### DIFF
--- a/bin/setup-redirects/index.js
+++ b/bin/setup-redirects/index.js
@@ -47,30 +47,35 @@ force = false
 #
 
 # Policies
+[[redirects]]
 from = "/docs/:version/policies/"
 to = "/docs/:version/policies/introduction/"
 status = 301
 force = false
 
 # Documentation
+[[redirects]]
 from = "/docs/:version/documentation/"
 to = "/docs/:version/documentation/introduction/"
 status = 301
 force = false
 
 # Overview
+[[redirects]]
 from = "/docs/:version/overview/"
 to = "/docs/:version/overview/what-is-kuma/"
 status = 301
 force = false
 
 # Installation
+[[redirects]]
 from = "/docs/:version/installation/"
 to = "/docs/:version/installation/centos/"
 status = 301
 force = false
 
 # Other
+[[redirects]]
 from = "/docs/:version/other/"
 to = "/docs/:version/other/introduction/"
 status = 301

--- a/bin/setup-redirects/index.js
+++ b/bin/setup-redirects/index.js
@@ -42,9 +42,37 @@ to = "/install/${latest}/:splat"
 status = 200
 force = false
 
-# Test redirect for old docs root pages
+#
+# Redirects for old docs root pages
+#
+
+# Policies
 from = "/docs/:version/policies/"
 to = "/docs/:version/policies/introduction/"
+status = 301
+force = false
+
+# Documentation
+from = "/docs/:version/documentation/"
+to = "/docs/:version/documentation/introduction/"
+status = 301
+force = false
+
+# Overview
+from = "/docs/:version/overview/"
+to = "/docs/:version/overview/what-is-kuma/"
+status = 301
+force = false
+
+# Installation
+from = "/docs/:version/installation/"
+to = "/docs/:version/installation/centos/"
+status = 301
+force = false
+
+# Other
+from = "/docs/:version/other/"
+to = "/docs/:version/other/introduction/"
 status = 301
 force = false`;
 

--- a/bin/setup-redirects/index.js
+++ b/bin/setup-redirects/index.js
@@ -40,6 +40,12 @@ force = false
 from = "/install/latest/*"
 to = "/install/${latest}/:splat"
 status = 200
+force = false
+
+# Test redirect for old docs root pages
+from = "/docs/:version/policies/"
+to = "/docs/:version/policies/introduction/"
+status = 301
 force = false`;
 
   // write our redirects to the TOML file


### PR DESCRIPTION
Added redirects that cover old root pages from the docs before the changes. Search engines are still holding onto some of these URLs, so this change covers those.

## URL redirects added:
- `/docs/:version/policies/` => `/docs/:version/policies/introduction/`
- `/docs/:version/documentation/` => `/docs/:version/documentation/introduction/`
- `/docs/:version/overview/` => `/docs/:version/overview/what-is-kuma/`
- `/docs/:version/installation/` => `/docs/:version/installation/centos/` _(CentOS is the first one in the list which is why it was used here)_
- `/docs/:version/other/` => `/docs/:version/other/introduction/`