### PR TITLE
Explicit force for Netlify redirects

### DIFF
--- a/bin/setup-redirects/index.js
+++ b/bin/setup-redirects/index.js
@@ -19,14 +19,14 @@ fs.readFile(releases, "utf8", (err, data) => {
 from = "/docs/"
 to = "/docs/${latest}/"
 status = ${docRedirectType}
-force = false
+force = true
 
 # Install redirect
 [[redirects]]
 from = "/install/"
 to = "/install/${latest}/"
 status = 200
-force = false
+force = true
 
 # Docs: Latest redirect
 [[redirects]]


### PR DESCRIPTION
This is a small change to (2) redirects (`/docs` and `/install`) that Netlify recommended changes for in an email to users. Learn more [at this blog post](https://community.netlify.com/t/changed-behavior-in-redirects/10084/13). These redirects are now explicitly forced to align with the bugfix that Netlify recently made and to prevent any issues when the bugfix goes live on April 7, 2020.