### PR TITLE
Community call form confirmation updates

### DIFF
--- a/docs/.vuepress/public/community-call-invite.ics
+++ b/docs/.vuepress/public/community-call-invite.ics
@@ -1,0 +1,60 @@
+BEGIN:VCALENDAR
+PRODID:-//Google Inc//Google Calendar 70.9054//EN
+VERSION:2.0
+CALSCALE:GREGORIAN
+METHOD:REQUEST
+BEGIN:VTIMEZONE
+TZID:America/Vancouver
+X-LIC-LOCATION:America/Vancouver
+BEGIN:DAYLIGHT
+TZOFFSETFROM:-0800
+TZOFFSETTO:-0700
+TZNAME:PDT
+DTSTART:19700308T020000
+RRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=2SU
+END:DAYLIGHT
+BEGIN:STANDARD
+TZOFFSETFROM:-0700
+TZOFFSETTO:-0800
+TZNAME:PST
+DTSTART:19701101T020000
+RRULE:FREQ=YEARLY;BYMONTH=11;BYDAY=1SU
+END:STANDARD
+END:VTIMEZONE
+BEGIN:VEVENT
+DTSTART;TZID=America/Vancouver:20200415T083000
+DTEND;TZID=America/Vancouver:20200415T090000
+RRULE:FREQ=WEEKLY;WKST=SU;INTERVAL=2;BYDAY=WE
+DTSTAMP:20200413T213413Z
+ORGANIZER;CN=kaitlyn.barnard@konghq.com:mailto:kaitlyn.barnard@konghq.com
+UID:2ppgbsrhemhhv0kpsrvusosqud@google.com
+ATTENDEE;CUTYPE=INDIVIDUAL;ROLE=REQ-PARTICIPANT;PARTSTAT=ACCEPTED;RSVP=TRUE
+ ;CN=kaitlyn.barnard@konghq.com;X-NUM-GUESTS=0:mailto:kaitlyn.barnard@konghq
+ .com
+ATTENDEE;CUTYPE=INDIVIDUAL;ROLE=REQ-PARTICIPANT;PARTSTAT=ACCEPTED;RSVP=TRUE
+ ;CN=Marco Palladino;X-NUM-GUESTS=0:mailto:marco@konghq.com
+ATTENDEE;CUTYPE=INDIVIDUAL;ROLE=REQ-PARTICIPANT;PARTSTAT=ACCEPTED;RSVP=TRUE
+ ;CN=kevin.chen@konghq.com;X-NUM-GUESTS=0:mailto:kevin.chen@konghq.com
+ATTENDEE;CUTYPE=INDIVIDUAL;ROLE=REQ-PARTICIPANT;PARTSTAT=NEEDS-ACTION;RSVP=
+ TRUE;CN=Team OCTO;X-NUM-GUESTS=0:mailto:team-octo@konghq.com
+ATTENDEE;CUTYPE=INDIVIDUAL;ROLE=REQ-PARTICIPANT;PARTSTAT=NEEDS-ACTION;RSVP=
+ TRUE;CN=Daryn St. Pierre;X-NUM-GUESTS=0:mailto:daryn.st.pierre@konghq.com
+X-MICROSOFT-CDO-OWNERAPPTID:-505765721
+CREATED:20200410T225057Z
+DESCRIPTION:Meeting Password:&nbsp\;<br>Open Agenda: <a href="https://tny.s
+ h/NXs6EVO">https://tny.sh/NXs6EVO</a>\n\n-::~:~::~:~:~:~:~:~:~:~:~:~:~:~:~:
+ ~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~::~:~::-\nPlease do not edit t
+ his section of the description.\n\nView your event at https://www.google.co
+ m/calendar/event?action=VIEW&eid=MnBwZ2JzcmhlbWhodjBrcHNydnVzb3NxdWQgZGFyeW
+ 4uc3QucGllcnJlQGtvbmdocS5jb20&tok=MjYja2FpdGx5bi5iYXJuYXJkQGtvbmdocS5jb202M
+ zdhNWQ2NGE0NjBlNzJjNWY2ODc5ODg2YjRlODljMDhlMmIyNTQ0&ctz=America%2FNew_York&
+ hl=en&es=1.\n-::~:~::~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:
+ ~:~:~:~:~:~:~:~:~::~:~::-
+LAST-MODIFIED:20200413T213411Z
+LOCATION:https://zoom.us/j/703864175
+SEQUENCE:0
+STATUS:CONFIRMED
+SUMMARY:Kuma Community Call
+TRANSP:OPAQUE
+END:VEVENT
+END:VCALENDAR

--- a/docs/.vuepress/theme/global-components/CommunityCallForm.vue
+++ b/docs/.vuepress/theme/global-components/CommunityCallForm.vue
@@ -56,7 +56,7 @@
           </a>
         </li>
         <li>
-          <a :href="invite">
+          <a :href="invite" target="_blank">
             <span class="icon">📅</span> Add to Your Calendar
           </a>
         </li>

--- a/docs/.vuepress/theme/global-components/CommunityCallForm.vue
+++ b/docs/.vuepress/theme/global-components/CommunityCallForm.vue
@@ -8,7 +8,7 @@
         v-if="formStatus === null || formStatus === false"
         class="form-horizontal"
         method="post"
-        :action="getCommunityCallSignupEndpoint"
+        :action="formEndpoint"
       >
         <input
           v-for="(key, value) in formData"
@@ -17,7 +17,7 @@
           :value="key"
           type="hidden"
         />
-        <input type="hidden" name="pardot-link" :value="getCommunityCallSignupEndpoint">
+        <input type="hidden" name="pardot-link" :value="formEndpoint">
         <label for="input_email" class="sr-only">Email</label>
         <validation-provider rules="required|email" v-slot="{ errors }">
           <input v-model="formData.email" id="email" name="email" type="email" placeholder="Email" />
@@ -49,6 +49,14 @@
         We've received your request to register for the upcoming Community Call.
         Thank you for your interest in {{ getSiteData.title }}!
       </p>
+      <ul class="inline-list">
+        <li>
+          <a :href="agenda" target="_blank">Agenda</a>
+        </li>
+        <li>
+          <a :href="invite">Add to Your Calendar</a>
+        </li>
+      </ul>
     </div>
 
     <div v-if="formStatus === false" class="danger custom-block">
@@ -102,9 +110,11 @@ export default {
     Spinner
   },
   computed: {
-    ...mapGetters([
-      'getCommunityCallSignupEndpoint'
-    ]),
+    ...mapGetters({
+      formEndpoint: 'getCommunityCallSignupEndpoint',
+      agenda: 'getCommunityCallAgendaUrl',
+      invite: 'getCommunityCallInvite'
+    }),
     formDistanceFromTop () {
       const marker = this.$refs['formMessageMarker']
 
@@ -178,9 +188,31 @@ button.is-sending {
 
 .form-wrapper {
     
-    form {
-      border-radius: 0;
-      overflow: visible;
+  form {
+    border-radius: 0;
+    overflow: visible;
+  }
+}
+
+.inline-list {
+  display: block;
+  overflow: hidden;
+  list-style: none;
+  margin: 10px 0 0 0 !important;
+  padding: 0;
+
+  li {
+    display: inline-block;
+
+    &:not(:last-of-type) {
+      border-right: 1px solid #ccc;
+      margin-right: 8px;
+      padding-right: 10px;
     }
   }
+
+  a {
+    text-decoration: underline;
+  }
+}
 </style>

--- a/docs/.vuepress/theme/global-components/CommunityCallForm.vue
+++ b/docs/.vuepress/theme/global-components/CommunityCallForm.vue
@@ -51,10 +51,14 @@
       </p>
       <ul class="inline-list">
         <li>
-          <a :href="agenda" target="_blank">Agenda</a>
+          <a :href="agenda" target="_blank">
+            <span class="icon">📝</span>  Agenda
+          </a>
         </li>
         <li>
-          <a :href="invite">Add to Your Calendar</a>
+          <a :href="invite">
+            <span class="icon">📅</span> Add to Your Calendar
+          </a>
         </li>
       </ul>
     </div>
@@ -212,7 +216,12 @@ button.is-sending {
   }
 
   a {
-    text-decoration: underline;
+    display: block;
+  }
+
+  .icon {
+    display: inline-block;
+    margin: 0 5px 0 0;
   }
 }
 </style>

--- a/docs/.vuepress/theme/store/index.js
+++ b/docs/.vuepress/theme/store/index.js
@@ -23,7 +23,7 @@ export default new Vuex.Store({
     newsletterPardotEndpointDev: 'https://go.pardot.com/l/392112/2020-01-14/bkwzrx',
     communityCallEndpoint: 'https://go.pardot.com/l/392112/2020-02-28/bl766m',
     communityCallAgendaUrl: 'https://tny.sh/NXs6EVO',
-    communityCallInvite: '/community-call-invite.ics'
+    communityCallInvite: 'https://calendar.google.com/calendar?cid=a29uZ2hxLmNvbV8xbWE5NnNzZGdnZmg5ZnJyY3M5N2VwdTM4b0Bncm91cC5jYWxlbmRhci5nb29nbGUuY29t'
   },
 
   getters: {

--- a/docs/.vuepress/theme/store/index.js
+++ b/docs/.vuepress/theme/store/index.js
@@ -21,7 +21,9 @@ export default new Vuex.Store({
     newsletterSignupEndpoint: 'https://script.google.com/macros/s/AKfycbx9xikTdHNrrnHiqxNX3ecVkTJYzPmKemrz2OMr6SaOXT7FYaiM/exec',
     newsletterPardotEndpoint: 'https://go.pardot.com/l/392112/2019-09-03/bjz6yv',
     newsletterPardotEndpointDev: 'https://go.pardot.com/l/392112/2020-01-14/bkwzrx',
-    communityCallEndpoint: 'https://go.pardot.com/l/392112/2020-02-28/bl766m'
+    communityCallEndpoint: 'https://go.pardot.com/l/392112/2020-02-28/bl766m',
+    communityCallAgendaUrl: 'https://tny.sh/NXs6EVO',
+    communityCallInvite: '/community-call-invite.ics'
   },
 
   getters: {
@@ -35,6 +37,8 @@ export default new Vuex.Store({
     getNewsletterPardotEndpoint: (state) => state.newsletterPardotEndpoint,
     getNewsletterPardotEndpointDev: (state) => state.newsletterPardotEndpointDev,
     getCommunityCallSignupEndpoint: (state) => state.communityCallEndpoint,
+    getCommunityCallAgendaUrl: (state) => state.communityCallAgendaUrl,
+    getCommunityCallInvite: (state) => state.communityCallInvite,
     releasesAsRouterLinks: (state) => {
       return state.releases.map( tag => ({
         text: tag === state.latestRelease ? `${tag} (latest)` : tag,


### PR DESCRIPTION
Added the agenda link and calendar invite (ICS file) to the Community Call form confirmation.

### To test locally
1. run `yarn docs:dev`
2. go to `http://localhost:8080/community/?form_success=true` (`?form_success=true` is the URL Salesforce will send the user back to after the form is submitted)

[Screenshot](https://share.getcloudapp.com/OAubbeQP)

You should see each link now in the confirmation the user is presented with after they've submitted the form.