### PR TITLE
Fix typos

### DIFF
--- a/docs/docs/0.1.0/documentation/backends.md
+++ b/docs/docs/0.1.0/documentation/backends.md
@@ -10,7 +10,7 @@ This information has been documented for clarity, but when following the [instal
 
 The backends are:
 
-* `memory` (**default**): Kuma stores all the state in-memory. This means that restarting Kuma will delete all the data. Only reccomend when playing with Kuma locally. For example:
+* `memory` (**default**): Kuma stores all the state in-memory. This means that restarting Kuma will delete all the data. Only recommend when playing with Kuma locally. For example:
 
 ```sh
 $ KUMA_STORE_TYPE=memory kuma-cp run

--- a/docs/docs/0.1.0/documentation/ports.md
+++ b/docs/docs/0.1.0/documentation/ports.md
@@ -5,5 +5,5 @@ When `kuma-cp` starts up, by default it listens on a few ports:
 * `5677`: the SDS server being used for propagating mTLS certificates across the data-planes.
 * `5678`: the xDS gRPC server implementation that the data-planes will use to retrieve their configuration.
 * `5680`: the HTTP server that returns the health status of the control-plane.
-* `5681`: the HTTP API server that is being used by `kumactl`, and that you can also use to retrieve Kuma's policies and - when runnning in `universal` - that you can use to apply new policies.
+* `5681`: the HTTP API server that is being used by `kumactl`, and that you can also use to retrieve Kuma's policies and - when running in `universal` - that you can use to apply new policies.
 * `5682`: the HTTP server that provides the Envoy bootstrap configuration when the data-plane starts up.

--- a/docs/docs/0.1.0/policies/applying-policies.md
+++ b/docs/docs/0.1.0/policies/applying-policies.md
@@ -25,4 +25,4 @@ echo "
 " | kubectl apply -f -
 ```
 
-Below you can find the policies that Kuma supports. In addition to [`kumactl`](../../documentation/kumactl), you can also retrive the state via the Kuma [HTTP API](../../documentation/http-api) as well.
+Below you can find the policies that Kuma supports. In addition to [`kumactl`](../../documentation/kumactl), you can also retrieve the state via the Kuma [HTTP API](../../documentation/http-api) as well.

--- a/docs/docs/0.1.1/documentation/backends.md
+++ b/docs/docs/0.1.1/documentation/backends.md
@@ -10,7 +10,7 @@ This information has been documented for clarity, but when following the [instal
 
 The backends are:
 
-* `memory` (**default**): Kuma stores all the state in-memory. This means that restarting Kuma will delete all the data. Only reccomend when playing with Kuma locally. For example:
+* `memory` (**default**): Kuma stores all the state in-memory. This means that restarting Kuma will delete all the data. Only recommend when playing with Kuma locally. For example:
 
 ```sh
 $ KUMA_STORE_TYPE=memory kuma-cp run

--- a/docs/docs/0.1.1/documentation/ports.md
+++ b/docs/docs/0.1.1/documentation/ports.md
@@ -5,5 +5,5 @@ When `kuma-cp` starts up, by default it listens on a few ports:
 * `5677`: the SDS server being used for propagating mTLS certificates across the data-planes.
 * `5678`: the xDS gRPC server implementation that the data-planes will use to retrieve their configuration.
 * `5680`: the HTTP server that returns the health status of the control-plane.
-* `5681`: the HTTP API server that is being used by `kumactl`, and that you can also use to retrieve Kuma's policies and - when runnning in `universal` - that you can use to apply new policies.
+* `5681`: the HTTP API server that is being used by `kumactl`, and that you can also use to retrieve Kuma's policies and - when running in `universal` - that you can use to apply new policies.
 * `5682`: the HTTP server that provides the Envoy bootstrap configuration when the data-plane starts up.

--- a/docs/docs/0.1.1/policies/applying-policies.md
+++ b/docs/docs/0.1.1/policies/applying-policies.md
@@ -25,4 +25,4 @@ echo "
 " | kubectl apply -f -
 ```
 
-Below you can find the policies that Kuma supports. In addition to [`kumactl`](../../documentation/kumactl), you can also retrive the state via the Kuma [HTTP API](../../documentation/http-api) as well.
+Below you can find the policies that Kuma supports. In addition to [`kumactl`](../../documentation/kumactl), you can also retrieve the state via the Kuma [HTTP API](../../documentation/http-api) as well.

--- a/docs/docs/0.1.2/documentation/backends.md
+++ b/docs/docs/0.1.2/documentation/backends.md
@@ -10,7 +10,7 @@ This information has been documented for clarity, but when following the [instal
 
 The backends are:
 
-* `memory` (**default**): Kuma stores all the state in-memory. This means that restarting Kuma will delete all the data. Only reccomend when playing with Kuma locally. For example:
+* `memory` (**default**): Kuma stores all the state in-memory. This means that restarting Kuma will delete all the data. Only recommend when playing with Kuma locally. For example:
 
 ```sh
 $ KUMA_STORE_TYPE=memory kuma-cp run

--- a/docs/docs/0.1.2/documentation/ports.md
+++ b/docs/docs/0.1.2/documentation/ports.md
@@ -5,5 +5,5 @@ When `kuma-cp` starts up, by default it listens on a few ports:
 * `5677`: the SDS server being used for propagating mTLS certificates across the data-planes.
 * `5678`: the xDS gRPC server implementation that the data-planes will use to retrieve their configuration.
 * `5680`: the HTTP server that returns the health status of the control-plane.
-* `5681`: the HTTP API server that is being used by `kumactl`, and that you can also use to retrieve Kuma's policies and - when runnning in `universal` - that you can use to apply new policies.
+* `5681`: the HTTP API server that is being used by `kumactl`, and that you can also use to retrieve Kuma's policies and - when running in `universal` - that you can use to apply new policies.
 * `5682`: the HTTP server that provides the Envoy bootstrap configuration when the data-plane starts up.

--- a/docs/docs/0.1.2/policies/applying-policies.md
+++ b/docs/docs/0.1.2/policies/applying-policies.md
@@ -25,4 +25,4 @@ echo "
 " | kubectl apply -f -
 ```
 
-Below you can find the policies that Kuma supports. In addition to [`kumactl`](../../documentation/kumactl), you can also retrive the state via the Kuma [HTTP API](../../documentation/http-api) as well.
+Below you can find the policies that Kuma supports. In addition to [`kumactl`](../../documentation/kumactl), you can also retrieve the state via the Kuma [HTTP API](../../documentation/http-api) as well.

--- a/docs/docs/0.2.0/documentation/backends.md
+++ b/docs/docs/0.2.0/documentation/backends.md
@@ -10,7 +10,7 @@ This information has been documented for clarity, but when following the [instal
 
 The backends are:
 
-* `memory` (**default**): Kuma stores all the state in-memory. This means that restarting Kuma will delete all the data. Only reccomend when playing with Kuma locally. For example:
+* `memory` (**default**): Kuma stores all the state in-memory. This means that restarting Kuma will delete all the data. Only recommend when playing with Kuma locally. For example:
 
 ```sh
 $ KUMA_STORE_TYPE=memory kuma-cp run

--- a/docs/docs/0.2.0/documentation/ports.md
+++ b/docs/docs/0.2.0/documentation/ports.md
@@ -5,5 +5,5 @@ When `kuma-cp` starts up, by default it listens on a few ports:
 * `5677`: the SDS server being used for propagating mTLS certificates across the data-planes.
 * `5678`: the xDS gRPC server implementation that the data-planes will use to retrieve their configuration.
 * `5680`: the HTTP server that returns the health status of the control-plane.
-* `5681`: the HTTP API server that is being used by `kumactl`, and that you can also use to retrieve Kuma's policies and - when runnning in `universal` - that you can use to apply new policies.
+* `5681`: the HTTP API server that is being used by `kumactl`, and that you can also use to retrieve Kuma's policies and - when running in `universal` - that you can use to apply new policies.
 * `5682`: the HTTP server that provides the Envoy bootstrap configuration when the data-plane starts up.

--- a/docs/docs/0.2.0/policies/applying-policies.md
+++ b/docs/docs/0.2.0/policies/applying-policies.md
@@ -25,4 +25,4 @@ echo "
 " | kubectl apply -f -
 ```
 
-Below you can find the policies that Kuma supports. In addition to [`kumactl`](../../documentation/kumactl), you can also retrive the state via the Kuma [HTTP API](../../documentation/http-api) as well.
+Below you can find the policies that Kuma supports. In addition to [`kumactl`](../../documentation/kumactl), you can also retrieve the state via the Kuma [HTTP API](../../documentation/http-api) as well.

--- a/docs/docs/0.2.1/documentation/backends.md
+++ b/docs/docs/0.2.1/documentation/backends.md
@@ -10,7 +10,7 @@ This information has been documented for clarity, but when following the [instal
 
 The backends are:
 
-* `memory` (**default**): Kuma stores all the state in-memory. This means that restarting Kuma will delete all the data. Only reccomend when playing with Kuma locally. For example:
+* `memory` (**default**): Kuma stores all the state in-memory. This means that restarting Kuma will delete all the data. Only recommend when playing with Kuma locally. For example:
 
 ```sh
 $ KUMA_STORE_TYPE=memory kuma-cp run

--- a/docs/docs/0.2.1/documentation/ports.md
+++ b/docs/docs/0.2.1/documentation/ports.md
@@ -5,5 +5,5 @@ When `kuma-cp` starts up, by default it listens on a few ports:
 * `5677`: the SDS server being used for propagating mTLS certificates across the data-planes.
 * `5678`: the xDS gRPC server implementation that the data-planes will use to retrieve their configuration.
 * `5680`: the HTTP server that returns the health status of the control-plane.
-* `5681`: the HTTP API server that is being used by `kumactl`, and that you can also use to retrieve Kuma's policies and - when runnning in `universal` - that you can use to apply new policies.
+* `5681`: the HTTP API server that is being used by `kumactl`, and that you can also use to retrieve Kuma's policies and - when running in `universal` - that you can use to apply new policies.
 * `5682`: the HTTP server that provides the Envoy bootstrap configuration when the data-plane starts up.

--- a/docs/docs/0.2.1/policies/applying-policies.md
+++ b/docs/docs/0.2.1/policies/applying-policies.md
@@ -25,4 +25,4 @@ echo "
 " | kubectl apply -f -
 ```
 
-Below you can find the policies that Kuma supports. In addition to [`kumactl`](../../documentation/kumactl), you can also retrive the state via the Kuma [HTTP API](../../documentation/http-api) as well.
+Below you can find the policies that Kuma supports. In addition to [`kumactl`](../../documentation/kumactl), you can also retrieve the state via the Kuma [HTTP API](../../documentation/http-api) as well.

--- a/docs/docs/0.2.2/documentation/backends.md
+++ b/docs/docs/0.2.2/documentation/backends.md
@@ -10,7 +10,7 @@ This information has been documented for clarity, but when following the [instal
 
 The backends are:
 
-* `memory` (**default**): Kuma stores all the state in-memory. This means that restarting Kuma will delete all the data. Only reccomend when playing with Kuma locally. For example:
+* `memory` (**default**): Kuma stores all the state in-memory. This means that restarting Kuma will delete all the data. Only recommend when playing with Kuma locally. For example:
 
 ```sh
 $ KUMA_STORE_TYPE=memory kuma-cp run

--- a/docs/docs/0.2.2/documentation/ports.md
+++ b/docs/docs/0.2.2/documentation/ports.md
@@ -5,5 +5,5 @@ When `kuma-cp` starts up, by default it listens on a few ports:
 * `5677`: the SDS server being used for propagating mTLS certificates across the data-planes.
 * `5678`: the xDS gRPC server implementation that the data-planes will use to retrieve their configuration.
 * `5680`: the HTTP server that returns the health status of the control-plane.
-* `5681`: the HTTP API server that is being used by `kumactl`, and that you can also use to retrieve Kuma's policies and - when runnning in `universal` - that you can use to apply new policies.
+* `5681`: the HTTP API server that is being used by `kumactl`, and that you can also use to retrieve Kuma's policies and - when running in `universal` - that you can use to apply new policies.
 * `5682`: the HTTP server that provides the Envoy bootstrap configuration when the data-plane starts up.

--- a/docs/docs/0.2.2/policies/applying-policies.md
+++ b/docs/docs/0.2.2/policies/applying-policies.md
@@ -25,4 +25,4 @@ echo "
 " | kubectl apply -f -
 ```
 
-Below you can find the policies that Kuma supports. In addition to [`kumactl`](../../documentation/kumactl), you can also retrive the state via the Kuma [HTTP API](../../documentation/http-api) as well.
+Below you can find the policies that Kuma supports. In addition to [`kumactl`](../../documentation/kumactl), you can also retrieve the state via the Kuma [HTTP API](../../documentation/http-api) as well.

--- a/docs/docs/0.3.0/documentation/backends.md
+++ b/docs/docs/0.3.0/documentation/backends.md
@@ -10,7 +10,7 @@ This information has been documented for clarity, but when following the [instal
 
 The backends are:
 
-* `memory` (**default**): Kuma stores all the state in-memory. This means that restarting Kuma will delete all the data. Only reccomend when playing with Kuma locally. For example:
+* `memory` (**default**): Kuma stores all the state in-memory. This means that restarting Kuma will delete all the data. Only recommend when playing with Kuma locally. For example:
 
 ```sh
 $ KUMA_STORE_TYPE=memory kuma-cp run

--- a/docs/docs/0.3.0/documentation/ports.md
+++ b/docs/docs/0.3.0/documentation/ports.md
@@ -6,6 +6,6 @@ When `kuma-cp` starts up, by default it listens on a few ports:
 * `5678`: the xDS gRPC server implementation that the data-planes will use to retrieve their configuration.
 * `5679`: the Dataplane Token Server that serves Dataplane Tokens
 * `5680`: the HTTP server that returns the health status of the control-plane.
-* `5681`: the HTTP API server that is being used by `kumactl`, and that you can also use to retrieve Kuma's policies and - when runnning in `universal` - that you can use to apply new policies.
+* `5681`: the HTTP API server that is being used by `kumactl`, and that you can also use to retrieve Kuma's policies and - when running in `universal` - that you can use to apply new policies.
 * `5682`: the HTTP server that provides the Envoy bootstrap configuration when the data-plane starts up.
 * `5683`: the HTTP server that exposes Kuma UI.

--- a/docs/docs/0.3.0/documentation/security.md
+++ b/docs/docs/0.3.0/documentation/security.md
@@ -76,7 +76,7 @@ Once a dataplane has proved its identity, it will be allowed to fetch its own id
 When establishing a connection between two dataplanes each side validates each other dataplane certificate confirming the identity using the root CA of the mesh.
 
 mTLS is _not_ enabled by default. To enable it, apply proper settings in [Mesh](../../policies/mesh) policy.
-Additionaly, when running on Universal you have to ensure that every dataplane in the mesh has been configured with a Dataplane Token.
+Additionally, when running on Universal you have to ensure that every dataplane in the mesh has been configured with a Dataplane Token.
 
 ### TrafficPermission
 When mTLS is enabled, every connection between dataplanes is denied by default, so you have to explicitly allow it using [TrafficPermission](../../policies/traffic-permissions).

--- a/docs/docs/0.3.0/policies/applying-policies.md
+++ b/docs/docs/0.3.0/policies/applying-policies.md
@@ -25,4 +25,4 @@ echo "
 " | kubectl apply -f -
 ```
 
-Below you can find the policies that Kuma supports. In addition to [`kumactl`](../../documentation/kumactl), you can also retrive the state via the Kuma [HTTP API](../../documentation/http-api) as well.
+Below you can find the policies that Kuma supports. In addition to [`kumactl`](../../documentation/kumactl), you can also retrieve the state via the Kuma [HTTP API](../../documentation/http-api) as well.

--- a/docs/docs/0.3.1/documentation/backends.md
+++ b/docs/docs/0.3.1/documentation/backends.md
@@ -10,7 +10,7 @@ This information has been documented for clarity, but when following the [instal
 
 The backends are:
 
-* `memory` (**default**): Kuma stores all the state in-memory. This means that restarting Kuma will delete all the data. Only reccomend when playing with Kuma locally. For example:
+* `memory` (**default**): Kuma stores all the state in-memory. This means that restarting Kuma will delete all the data. Only recommend when playing with Kuma locally. For example:
 
 ```sh
 $ KUMA_STORE_TYPE=memory kuma-cp run

--- a/docs/docs/0.3.1/documentation/ports.md
+++ b/docs/docs/0.3.1/documentation/ports.md
@@ -6,6 +6,6 @@ When `kuma-cp` starts up, by default it listens on a few ports:
 * `5678`: the xDS gRPC server implementation that the data-planes will use to retrieve their configuration.
 * `5679`: the Admin Server that serves Dataplane Tokens and manages Provided Certificate Authority
 * `5680`: the HTTP server that returns the health status of the control-plane.
-* `5681`: the HTTP API server that is being used by `kumactl`, and that you can also use to retrieve Kuma's policies and - when runnning in `universal` - that you can use to apply new policies.
+* `5681`: the HTTP API server that is being used by `kumactl`, and that you can also use to retrieve Kuma's policies and - when running in `universal` - that you can use to apply new policies.
 * `5682`: the HTTP server that provides the Envoy bootstrap configuration when the data-plane starts up.
 * `5683`: the HTTP server that exposes Kuma UI.

--- a/docs/docs/0.3.1/documentation/security.md
+++ b/docs/docs/0.3.1/documentation/security.md
@@ -85,7 +85,7 @@ Once a dataplane has proved its identity, it will be allowed to fetch its own id
 When establishing a connection between two dataplanes each side validates each other dataplane certificate confirming the identity using the root CA of the mesh.
 
 mTLS is _not_ enabled by default. To enable it, apply proper settings in [Mesh](../../policies/mesh) policy.
-Additionaly, when running on Universal you have to ensure that every dataplane in the mesh has been configured with a Dataplane Token.
+Additionally, when running on Universal you have to ensure that every dataplane in the mesh has been configured with a Dataplane Token.
 
 ### TrafficPermission
 When mTLS is enabled, every connection between dataplanes is denied by default, so you have to explicitly allow it using [TrafficPermission](../../policies/traffic-permissions).

--- a/docs/docs/0.3.1/policies/applying-policies.md
+++ b/docs/docs/0.3.1/policies/applying-policies.md
@@ -25,4 +25,4 @@ echo "
 " | kubectl apply -f -
 ```
 
-Below you can find the policies that Kuma supports. In addition to [`kumactl`](../../documentation/kumactl), you can also retrive the state via the Kuma [HTTP API](../../documentation/http-api) as well.
+Below you can find the policies that Kuma supports. In addition to [`kumactl`](../../documentation/kumactl), you can also retrieve the state via the Kuma [HTTP API](../../documentation/http-api) as well.

--- a/docs/docs/0.3.2/documentation/backends.md
+++ b/docs/docs/0.3.2/documentation/backends.md
@@ -10,7 +10,7 @@ This information has been documented for clarity, but when following the [instal
 
 The backends are:
 
-* `memory` (**default**): Kuma stores all the state in-memory. This means that restarting Kuma will delete all the data. Only reccomend when playing with Kuma locally. For example:
+* `memory` (**default**): Kuma stores all the state in-memory. This means that restarting Kuma will delete all the data. Only recommend when playing with Kuma locally. For example:
 
 ```sh
 $ KUMA_STORE_TYPE=memory kuma-cp run

--- a/docs/docs/0.3.2/documentation/dps-and-data-model.md
+++ b/docs/docs/0.3.2/documentation/dps-and-data-model.md
@@ -192,7 +192,7 @@ On Kubernetes the [`Dataplane`](#dataplane-entity) entity is also automatically 
 The `Dataplane` can operate in Gateway mode. This way you can integrate Kuma with existing API Gateways like [Kong](https://github.com/Kong/kong).
 
 When you use a Dataplane with a service, both inbound traffic to a service and outbound traffic from the service flows through the Dataplane.
-API Gateway should be deployed as any other service withing the mesh. However, in this case we want inbound traffic to go directly to API Gateway,
+API Gateway should be deployed as any other service within the mesh. However, in this case we want inbound traffic to go directly to API Gateway,
 otherwise clients would have to be provided with certificates that are generated dynamically for communication between services within the mesh.
 Security for an entrance to the mesh should be handled by API Gateway itself.
 

--- a/docs/docs/0.3.2/documentation/networking.md
+++ b/docs/docs/0.3.2/documentation/networking.md
@@ -13,7 +13,7 @@ When `kuma-cp` starts up, by default it listens on a few ports:
 * `5678`: the xDS gRPC server implementation that the data-planes will use to retrieve their configuration.
 * `5679`: the Admin Server that serves Dataplane Tokens and manages Provided Certificate Authority
 * `5680`: the HTTP server that returns the health status of the control-plane.
-* `5681`: the HTTP API server that is being used by `kumactl`, and that you can also use to retrieve Kuma's policies and - when runnning in `universal` - that you can use to apply new policies.
+* `5681`: the HTTP API server that is being used by `kumactl`, and that you can also use to retrieve Kuma's policies and - when running in `universal` - that you can use to apply new policies.
 * `5682`: the HTTP server that provides the Envoy bootstrap configuration when the data-plane starts up.
 * `5683`: the HTTP server that exposes Kuma UI.
 

--- a/docs/docs/0.3.2/documentation/security.md
+++ b/docs/docs/0.3.2/documentation/security.md
@@ -87,7 +87,7 @@ Once a dataplane has proved its identity, it will be allowed to fetch its own id
 When establishing a connection between two dataplanes each side validates each other dataplane certificate confirming the identity using the root CA of the mesh.
 
 mTLS is _not_ enabled by default. To enable it, apply proper settings in [Mesh](../../policies/mesh) policy.
-Additionaly, when running on Universal you have to ensure that every dataplane in the mesh has been configured with a Dataplane Token.
+Additionally, when running on Universal you have to ensure that every dataplane in the mesh has been configured with a Dataplane Token.
 
 ### TrafficPermission
 When mTLS is enabled, every connection between dataplanes is denied by default, so you have to explicitly allow it using [TrafficPermission](../../policies/traffic-permissions).

--- a/docs/docs/0.3.2/policies/applying-policies.md
+++ b/docs/docs/0.3.2/policies/applying-policies.md
@@ -25,4 +25,4 @@ echo "
 " | kubectl apply -f -
 ```
 
-Below you can find the policies that Kuma supports. In addition to [`kumactl`](../../documentation/kumactl), you can also retrive the state via the Kuma [HTTP API](../../documentation/http-api) as well.
+Below you can find the policies that Kuma supports. In addition to [`kumactl`](../../documentation/kumactl), you can also retrieve the state via the Kuma [HTTP API](../../documentation/http-api) as well.

--- a/docs/docs/0.3.2/policies/mutual-tls.md
+++ b/docs/docs/0.3.2/policies/mutual-tls.md
@@ -11,7 +11,7 @@ By default, mTLS is **not** enabled. You can enable Mutual TLS by updating the [
 ::: tip
 With mTLS enabled, all traffic is denied by default.
 
-Remember to apply a `TrafficPermission` policy to explictly allow legitimate traffic between certain Dataplanes.
+Remember to apply a `TrafficPermission` policy to explicitly allow legitimate traffic between certain Dataplanes.
 :::
 
 ## Builtin CA
@@ -53,7 +53,7 @@ To that end, Kuma supports another type of CA - `provided` CA.
 
 Like the name implies, a user will have to provide a custom Root CA certificate and take a responsibility for managing its lifecycle.
 
-A complete workflow of chaning CA type from `builtin` to `provided` looks the following way:
+A complete workflow of changing CA type from `builtin` to `provided` looks the following way:
 
 1. A user must first upload a custom Root CA certificate using `kumactl manage ca provided` command, e.g.
 

--- a/docs/docs/0.4.0/documentation/backends.md
+++ b/docs/docs/0.4.0/documentation/backends.md
@@ -12,7 +12,7 @@ Following backends are available
 
 ## Memory
 
-Kuma stores all the state in-memory. This means that restarting Kuma will delete all the data. Only reccomend when playing with Kuma locally. For example:
+Kuma stores all the state in-memory. This means that restarting Kuma will delete all the data. Only recommend when playing with Kuma locally. For example:
 
 ```sh
 $ KUMA_STORE_TYPE=memory kuma-cp run

--- a/docs/docs/0.4.0/documentation/dps-and-data-model.md
+++ b/docs/docs/0.4.0/documentation/dps-and-data-model.md
@@ -236,7 +236,7 @@ On Kubernetes the [`Dataplane`](#dataplane-entity) entity is also automatically 
 The `Dataplane` can operate in Gateway mode. This way you can integrate Kuma with existing API Gateways like [Kong](https://github.com/Kong/kong).
 
 When you use a Dataplane with a service, both inbound traffic to a service and outbound traffic from the service flows through the Dataplane.
-API Gateway should be deployed as any other service withing the mesh. However, in this case we want inbound traffic to go directly to API Gateway,
+API Gateway should be deployed as any other service within the mesh. However, in this case we want inbound traffic to go directly to API Gateway,
 otherwise clients would have to be provided with certificates that are generated dynamically for communication between services within the mesh.
 Security for an entrance to the mesh should be handled by API Gateway itself.
 

--- a/docs/docs/0.4.0/documentation/networking.md
+++ b/docs/docs/0.4.0/documentation/networking.md
@@ -13,7 +13,7 @@ When `kuma-cp` starts up, by default it listens on a few ports:
 * `5678`: the xDS gRPC server implementation that the data-planes will use to retrieve their configuration.
 * `5679`: the Admin Server that serves Dataplane Tokens and manages Provided Certificate Authority
 * `5680`: the HTTP server that returns the health status of the control-plane.
-* `5681`: the HTTP API server that is being used by `kumactl`, and that you can also use to retrieve Kuma's policies and - when runnning in `universal` - that you can use to apply new policies.
+* `5681`: the HTTP API server that is being used by `kumactl`, and that you can also use to retrieve Kuma's policies and - when running in `universal` - that you can use to apply new policies.
 * `5682`: the HTTP server that provides the Envoy bootstrap configuration when the data-plane starts up.
 * `5683`: the HTTP server that exposes Kuma UI.
 

--- a/docs/docs/0.4.0/documentation/security.md
+++ b/docs/docs/0.4.0/documentation/security.md
@@ -87,7 +87,7 @@ Once a dataplane has proved its identity, it will be allowed to fetch its own id
 When establishing a connection between two dataplanes each side validates each other dataplane certificate confirming the identity using the root CA of the mesh.
 
 mTLS is _not_ enabled by default. To enable it, apply proper settings in [Mesh](../../policies/mesh) policy.
-Additionaly, when running on Universal you have to ensure that every dataplane in the mesh has been configured with a Dataplane Token.
+Additionally, when running on Universal you have to ensure that every dataplane in the mesh has been configured with a Dataplane Token.
 
 ### TrafficPermission
 When mTLS is enabled, every connection between dataplanes is denied by default, so you have to explicitly allow it using [TrafficPermission](../../policies/traffic-permissions).

--- a/docs/docs/0.4.0/policies/applying-policies.md
+++ b/docs/docs/0.4.0/policies/applying-policies.md
@@ -25,4 +25,4 @@ echo "
 " | kubectl apply -f -
 ```
 
-Below you can find the policies that Kuma supports. In addition to [`kumactl`](../../documentation/kumactl), you can also retrive the state via the Kuma [HTTP API](../../documentation/http-api) as well.
+Below you can find the policies that Kuma supports. In addition to [`kumactl`](../../documentation/kumactl), you can also retrieve the state via the Kuma [HTTP API](../../documentation/http-api) as well.

--- a/docs/docs/0.4.0/policies/mutual-tls.md
+++ b/docs/docs/0.4.0/policies/mutual-tls.md
@@ -11,7 +11,7 @@ By default, mTLS is **not** enabled. You can enable Mutual TLS by updating the [
 ::: tip
 With mTLS enabled, all traffic is denied by default.
 
-Remember to apply a `TrafficPermission` policy to explictly allow legitimate traffic between certain Dataplanes.
+Remember to apply a `TrafficPermission` policy to explicitly allow legitimate traffic between certain Dataplanes.
 :::
 
 ### Builtin CA
@@ -53,7 +53,7 @@ To that end, Kuma supports another type of CA - `provided` CA.
 
 Like the name implies, a user will have to provide a custom Root CA certificate and take a responsibility for managing its lifecycle.
 
-A complete workflow of chaning CA type from `builtin` to `provided` looks the following way:
+A complete workflow of changing CA type from `builtin` to `provided` looks the following way:
 
 1. A user must first upload a custom Root CA certificate using `kumactl manage ca provided` command, e.g.
 

--- a/docs/docs/0.4.0/policies/traffic-log.md
+++ b/docs/docs/0.4.0/policies/traffic-log.md
@@ -37,7 +37,7 @@ logging:
       # Use `file` field to configure a file-based logging backend.
       file:
         path: /tmp/access.log
-      # When `format` field is ommitted, the default access log format will be used.
+      # When `format` field is omitted, the default access log format will be used.
 ```
 
 ```yaml
@@ -96,7 +96,7 @@ spec:
         # Use `file` field to configure a file-based logging backend.
         file:
           path: /tmp/access.log
-        # When `format` field is ommitted, the default access log format will be used.
+        # When `format` field is omitted, the default access log format will be used.
 ```
 
 ```yaml


### PR DESCRIPTION
Hello,

This PR will fix : 

- 1 typo in `docs/docs/0.4.0/documentation/backends.md`
- 1 typo in `docs/docs/0.4.0/documentation/dps-and-data-model.md`
- 1 typo in `docs/docs/0.4.0/documentation/networking.md`
- 1 typo in `docs/docs/0.4.0/documentation/security.md`
- 1 typo in `docs/docs/0.4.0/policies/applying-policies.md`
- 2 typos in `docs/docs/0.4.0/policies/mutual-tls.md`
- 2 typos in `docs/docs/0.4.0/policies/traffic-log.md`



Cheers! :robot: