### PR TITLE
Fix the v0.5.0 docs

### DIFF
--- a/docs/docs/0.5.0/installation/amazonlinux.md
+++ b/docs/docs/0.5.0/installation/amazonlinux.md
@@ -90,9 +90,10 @@ or you can enable mTLS on the `default` Mesh with:
 echo "type: Mesh
 name: default
 mtls:
-  enabled: true
-  ca:
-    builtin: {}" | kumactl apply -f -
+  enabledBackend: ca-1
+  backends:
+  - name: ca-1
+    type: builtin" | kumactl apply -f -
 ```
 
 You can configure `kumactl` to point to any remote `kuma-cp` instance by running:

--- a/docs/docs/0.5.0/installation/docker.md
+++ b/docs/docs/0.5.0/installation/docker.md
@@ -73,9 +73,10 @@ or you can enable mTLS on the `default` Mesh with:
 echo "type: Mesh
 name: default
 mtls:
-  enabled: true
-  ca:
-    builtin: {}" | docker run -i --net="host" \
+  enabledBackend: ca-1
+  backends:
+  - name: ca-1
+    type: builtin" | docker run -i --net="host" \
   kong-docker-kuma-docker.bintray.io/kumactl:0.5.0 kumactl apply -f -
 ```
 

--- a/docs/docs/0.5.0/installation/openshift.md
+++ b/docs/docs/0.5.0/installation/openshift.md
@@ -141,9 +141,10 @@ metadata:
   name: default
 spec:
   mtls:
-    enabled: true
-    ca:
-      builtin: {}" | oc apply -f -
+    enabledBackend: ca-1
+    backends:
+    - name: ca-1
+      type: builtin" | oc apply -f -
 ```
 
 :::

--- a/docs/docs/0.5.0/quickstart/kubernetes.md
+++ b/docs/docs/0.5.0/quickstart/kubernetes.md
@@ -130,9 +130,10 @@ metadata:
   name: default
 spec:
   mtls:
-    enabled: true
-    ca:
-      builtin: {} | kubectl apply -f -"
+    enabledBackend: ca-1
+    backends:
+    - name: ca-1
+      type: builtin" | kubectl apply -f -
 ```
 
 Once Mutual TLS has been enabled, Kuma will **not allow** traffic to flow freely across our services unless we explicitly create a [Traffic Permission](/docs/0.5.0/policies/traffic-permissions/) policy that describes what services can be consumed by other services. You can try to make requests to the demo application at [`127.0.0.1:8080/`](http://127.0.0.1:8080/) and you will notice that they will **not** work.
@@ -188,11 +189,15 @@ metadata:
   name: default
 spec:
   mtls:
-    enabled: true
-    ca:
-      builtin: {} 
+    enabledBackend: ca-1
+    backends:
+    - name: ca-1
+      type: builtin
   metrics:
-    prometheus: {}" | kubectl apply -f -
+    enabledBackend: prometheus-1
+    backends:
+    - name: prometheus-1
+      type: prometheus" | kubectl apply -f -
 ```
 
 This will enable the `prometheus` metrics backend on the `default` [Mesh](/docs/0.5.0/policies/mesh/) and automatically collect metrics for all of our traffic.

--- a/docs/docs/0.5.0/quickstart/kubernetes.md
+++ b/docs/docs/0.5.0/quickstart/kubernetes.md
@@ -208,7 +208,7 @@ Now let's go ahead and generate some traffic - to populate our charts - by using
 You can also generate some artificial traffic with the following command to save some clicks:
 
 ```sh
-while [ true ]; do curl http://127.0.0.1:8081/items?q=; curl http://127.0.0.1:8081/items/1/reviews; done
+while [ true ]; do curl http://127.0.0.1:8080/items?q=; curl http://127.0.0.1:8080/items/1/reviews; done
 ```
 :::
 

--- a/docs/docs/0.5.0/quickstart/universal.md
+++ b/docs/docs/0.5.0/quickstart/universal.md
@@ -106,9 +106,10 @@ $ cat <<EOF | kumactl apply -f -
 type: Mesh
 name: default
 mtls:
-  enabled: true
-  ca:
-    builtin: {}
+  enabledBackend: ca-1
+  backends:
+  - name: ca-1
+    type: builtin
 EOF
 ```
 
@@ -151,11 +152,15 @@ $ cat <<EOF | kumactl apply -f -
 type: Mesh
 name: default
 mtls:
-  enabled: true
-  ca:
-    builtin: {}
+  enabledBackend: ca-1
+  backends:
+  - name: ca-1
+    type: builtin
 metrics:
-  prometheus: {}
+  enabledBackend: prometheus-1
+  backends:
+  - name: prometheus-1
+    type: prometheus
 EOF
 ```
 


### PR DESCRIPTION
I fixed examples of `Mesh` resource and an example of the command to generate traffic on [the v0.5.0 docs](https://kuma.io/docs/0.5.0/). 

Refs:

- https://kuma.io/docs/0.5.0/policies/mutual-tls/
- https://kuma.io/docs/0.5.0/policies/traffic-metrics/
