### PR TITLE
Policies page tile hover fix

### DIFF
--- a/docs/.vuepress/theme/components/custom/Policies.vue
+++ b/docs/.vuepress/theme/components/custom/Policies.vue
@@ -143,7 +143,8 @@ export default {
     transform 200ms $cubic-bezier;
 
   &:hover, &:active {
-    transform: scale(1.05);
+    // no more scale on hover because Chrome on Retina does not play nice with it
+    // transform: scale(1.05);
     border: 1px solid $hover-color;
     color: $hover-color;
 


### PR DESCRIPTION
Disabled the upscaling on hover for the Policies page tiles because Chrome on Retina screens has a recurring issue with it. Random borders disappear after hover when paired with TailwindCSS grid columns. The only real fix right now is to disable the scaling that occurs on hover.