### PR TITLE
Access-Control-Allow-Origin CORS header for latest version URL

### DIFF
--- a/bin/setup-redirects/index.js
+++ b/bin/setup-redirects/index.js
@@ -91,7 +91,8 @@ force = true
 [[headers]]
   for = "/latest_version"
   [headers.values]
-    Content-Type = "text/plain"`;
+    Content-Type = "text/plain"
+    Access-Control-Allow-Origin = "*"`;
 
   // write our redirects to the TOML file
   // this will write to the end of the file


### PR DESCRIPTION
This PR adds a wildcard `Access-Control-Allow-Origin` header for the `[latest_version](https://kuma.io/latest_version)` URL so that we can properly fetch the latest version string in things like front end apps where this is very strict.