### PR TITLE
docs(*) dataplane outbound new format

### DIFF
--- a/docs/docs/0.5.1/documentation/dps-and-data-model.md
+++ b/docs/docs/0.5.1/documentation/dps-and-data-model.md
@@ -88,7 +88,8 @@ networking:
       protocol: http
   outbound:
   - port: 10000
-    service: redis" | kumactl apply -f -
+    tags:
+      service: redis" | kumactl apply -f -
 
 kuma-dp run \
   --name=backend-1 \
@@ -151,7 +152,8 @@ networking:
         protocol: http
   outbound:
     - port: 33033
-      service: redis
+      tags:
+        service: redis
 ```
 And the [`Gateway mode`](#gateway)'s entity definition will look like:
 ```yaml
@@ -165,7 +167,8 @@ networking:
       service: kong
   outbound:
   - port: 33033
-    service: backend
+    tags:
+      service: backend
 ```
 
 The `Dataplane` entity includes a few sections:
@@ -257,7 +260,8 @@ networking:
       service: kong
   outbound:
   - port: 33033
-    service: backend
+    tags:
+      service: backend
 ```
 
 When configuring your API Gateway to pass traffic to _backend_ set the url to `http://localhost:33033` 

--- a/docs/docs/0.5.1/documentation/http-api.md
+++ b/docs/docs/0.5.1/documentation/http-api.md
@@ -475,11 +475,15 @@ curl http://localhost:5681/meshes/mesh-1/dataplanes/backend-1
     "outbound": [
       {
         "port": 33033,
-        "service": "database"
+        "tags": {
+          "service": "database"
+        }
       },
       {
         "port": 44044,
-        "service": "user"
+        "tags": {
+          "service": "user"
+        }
       }
     ]
   }
@@ -516,11 +520,15 @@ curl -XPUT http://localhost:5681/meshes/mesh-1/dataplanes/backend-1 --data @data
     "outbound": [
       {
         "port": 33033,
-        "service": "database"
+        "tags": {
+          "service": "database"
+        }
       },
       {
         "port": 44044,
-        "service": "user"
+        "tags": {
+          "service": "user"
+        }
       }
     ]
   }
@@ -561,11 +569,15 @@ curl http://localhost:5681/meshes/mesh-1/dataplanes
         "outbound": [
           {
             "port": 33033,
-            "service": "database"
+            "tags": {
+              "service": "database"
+            }
           },
           {
             "port": 44044,
-            "service": "user"
+            "tags": {
+              "service": "user"
+            }
           }
         ]
       }
@@ -620,7 +632,9 @@ curl http://localhost:5681/meshes/default/dataplanes+insights/example
    "outbound": [
     {
      "port": 33033,
-     "service": "database"
+     "tags": {
+      "service": "database"
+     }      
     }
    ]
   }
@@ -692,7 +706,9 @@ curl http://localhost:5681/meshes/default/dataplanes+insights
        "outbound": [
         {
          "port": 33033,
-         "service": "database"
+         "tags": {
+          "service": "database"
+         }
         }
        ]
       }


### PR DESCRIPTION
Change DP format to new outbound with tags. This is backwards compatible change - meaning you can still use `service: backend`